### PR TITLE
feat: Bid Pipeline Sync Controls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 | SharePoint Sheet Sync (portal → E-LOGIC BID PIPELINE xlsx via Graph API) | built | — |
 | Comment Mentions & Notifications (@mention users in comments, in-app bell + email via per-user MS OAuth) | built | [features/comment-mentions-notifications.md](features/comment-mentions-notifications.md) |
 | Bid Requirement Fields (Site Visit, Q&A Deadline, Resumes on quotes + sheet sync) | built | — |
+| Bid Pipeline Sync Controls (`sync_to_sheet` flag, bid-type smart default, human-owned sheet columns, master-linked quotes keep syncing) | built | — |
 
 ## Environment
 
@@ -83,11 +84,11 @@ A quote (`Rfq`) progresses through: Created → Completed → Submitted → Awar
 ### SharePoint Sheet Sync — row-pointer invariants
 
 The DB column `rfq.sheet_row` is the source of truth for which sheet row a quote owns; the sheet itself (Graph `usedRange`) is only **eventually consistent**, so never decide append-vs-update by scanning it when a pointer exists.
-- `syncRow($sheetRow,…)` is **self-healing**: it verifies column A of `$sheetRow` equals the quote id before writing; if it drifted it re-resolves via `appendRow` (column-A scan) and returns the corrected row — callers must persist the returned value.
-- `appendRow` reads only row-count + column A (not the full grid) and overwrites a matching row if found, else appends.
-- **Break Sync** keeps `sheet_row` (only sets status `never`); auto-sync is gated on status `synced`, not on having a row — so re-sync re-attaches instead of duplicating.
+- `syncRow($sheetRow,…)` is **self-healing**: it reads the full `A:T` of `$sheetRow`, verifies column A equals the quote id before writing; if it drifted it re-resolves via `appendRow` (column-A scan) and returns the corrected row — callers must persist the returned value.
+- `appendRow` reads row-count + column A to find/append; before overwriting an existing row it reads that row's `A:T` so human columns survive.
 - After `deleteRow` (shift='Up'), call `SheetSyncRepository::shiftRowsAfterDelete()` to decrement pointers below the deleted row.
-- Child/multi-year quotes never sync. Only bid types `Audio Visual` and `Services` auto-sync.
+- **Per-quote `sync_to_sheet` flag is the sole auto-sync gate** (not bid type, not child/master-link). Creation form's "Sync to pipeline" checkbox sets it (JS smart-defaults it from bid type via the syncable list — all A/V variants + `IT`/`MOVING & LOGISTICS`/`PROFESSIONAL SERVICES`/`Services` — but the user can override). `Sync to Sheet` btn sets flag=1 (+status `synced`); `Break Sync` sets flag=0 (keeps `sheet_row`, status `never`). `copyRfq` sets copies to 0.
+- **Read-merge-write column ownership** (`SheetSyncService::mergeAppOwned`): app rewrites A,B,C,D,F,G,H,J,L,M,N,Q,T each sync; **E (STATUS), I, K, O, P, R, S are human-owned** and preserved (blank on brand-new rows). Status transitions in `guardar_editar_cotizacion.php` no longer push STATUS (that helper is now a no-op).
 
 ### Unified Audit Trail
 

--- a/app/Quote/RepositorioRfq.inc.php
+++ b/app/Quote/RepositorioRfq.inc.php
@@ -4,7 +4,7 @@ class RepositorioRfq {
     $cotizacion_insertada = false;
     if (isset($conexion)) {
       try {
-        $sql = 'INSERT INTO rfq(id_usuario, usuario_designado, canal, email_code, type_of_bid, issue_date, end_date, status, completado, total_cost, total_price, comments, award, fecha_completado, fecha_submitted, fecha_award, payment_terms, address, ship_to, expiration_date, ship_via, taxes, profit, additional, shipping, shipping_cost, fullfillment, fulfillment_date, contract_number, fulfillment_profit, services_fulfillment_profit, total_fulfillment, total_services_fulfillment, invoice, invoice_date, multi_year_project, submitted_invoice, submitted_invoice_date, fulfillment_pending, fulfillment_shipping_cost, fulfillment_shipping, type_of_contract, net30_fulfillment, sales_commission, city, zip_code, state, client, reference_url, priority, name, site_visit, resumes, qa_deadline, internal_due_date, qa) VALUES(:id_usuario, :usuario_designado, :canal, :email_code, :type_of_bid, :issue_date, :end_date, :status, :completado, :total_cost, :total_price, :comments, :award, :fecha_completado, :fecha_submitted, :fecha_award, :payment_terms, :address, :ship_to, :expiration_date, :ship_via, :taxes, :profit, :additional, :shipping, :shipping_cost, :fullfillment, :fulfillment_date, :contract_number, :fulfillment_profit, :services_fulfillment_profit, :total_fulfillment, :total_services_fulfillment, :invoice, :invoice_date, :multi_year_project, :submitted_invoice, :submitted_invoice_date, :fulfillment_pending, :fulfillment_shipping_cost, :fulfillment_shipping, :type_of_contract, :net30_fulfillment, :sales_commission, :city, :zip_code, :state, :client, :reference_url, :priority, :name, :site_visit, :resumes, STR_TO_DATE(:qa_deadline, \'%m/%d/%Y %H:%i\'), STR_TO_DATE(:internal_due_date, \'%m/%d/%Y\'), :qa)';
+        $sql = 'INSERT INTO rfq(id_usuario, usuario_designado, canal, email_code, type_of_bid, issue_date, end_date, status, completado, total_cost, total_price, comments, award, fecha_completado, fecha_submitted, fecha_award, payment_terms, address, ship_to, expiration_date, ship_via, taxes, profit, additional, shipping, shipping_cost, fullfillment, fulfillment_date, contract_number, fulfillment_profit, services_fulfillment_profit, total_fulfillment, total_services_fulfillment, invoice, invoice_date, multi_year_project, submitted_invoice, submitted_invoice_date, fulfillment_pending, fulfillment_shipping_cost, fulfillment_shipping, type_of_contract, net30_fulfillment, sales_commission, city, zip_code, state, client, reference_url, priority, name, sync_to_sheet, site_visit, resumes, qa_deadline, internal_due_date, qa) VALUES(:id_usuario, :usuario_designado, :canal, :email_code, :type_of_bid, :issue_date, :end_date, :status, :completado, :total_cost, :total_price, :comments, :award, :fecha_completado, :fecha_submitted, :fecha_award, :payment_terms, :address, :ship_to, :expiration_date, :ship_via, :taxes, :profit, :additional, :shipping, :shipping_cost, :fullfillment, :fulfillment_date, :contract_number, :fulfillment_profit, :services_fulfillment_profit, :total_fulfillment, :total_services_fulfillment, :invoice, :invoice_date, :multi_year_project, :submitted_invoice, :submitted_invoice_date, :fulfillment_pending, :fulfillment_shipping_cost, :fulfillment_shipping, :type_of_contract, :net30_fulfillment, :sales_commission, :city, :zip_code, :state, :client, :reference_url, :priority, :name, :sync_to_sheet, :site_visit, :resumes, STR_TO_DATE(:qa_deadline, \'%m/%d/%Y %H:%i\'), STR_TO_DATE(:internal_due_date, \'%m/%d/%Y\'), :qa)';
         $sentencia = $conexion->prepare($sql);
         $sentencia->bindValue(':id_usuario', $cotizacion->obtener_id_usuario(), PDO::PARAM_STR);
         $sentencia->bindValue(':usuario_designado', $cotizacion->obtener_usuario_designado(), PDO::PARAM_STR);
@@ -57,6 +57,7 @@ class RepositorioRfq {
         $sentencia->bindValue(':reference_url', $cotizacion->getReferenceUrl(), PDO::PARAM_STR);
         $sentencia->bindValue(':priority', $cotizacion->getPriority(), PDO::PARAM_STR);
         $sentencia->bindValue(':name', $cotizacion->getName(), PDO::PARAM_STR);
+        $sentencia->bindValue(':sync_to_sheet', $cotizacion->getSyncToSheet(), PDO::PARAM_INT);
         $sentencia->bindValue(':site_visit', $cotizacion->getSiteVisit(), PDO::PARAM_INT);
         $sentencia->bindValue(':resumes', $cotizacion->getResumes(), PDO::PARAM_INT);
         $sentencia->bindValue(':qa_deadline', $cotizacion->getQaDeadline(), PDO::PARAM_STR);
@@ -2411,6 +2412,9 @@ class RepositorioRfq {
       'bpa' => $cotizacion->getBpa(),
       'reference_url' => $cotizacion->getReferenceUrl(),
       'priority' => null,
+      // Copies start un-synced so duplicating across years doesn't flood the pipeline;
+      // the user can opt a copy back in with the Sync to Sheet button.
+      'sync_to_sheet' => 0,
     ]);
 
     // Insert the copied RFQ

--- a/app/Quote/Rfq.inc.php
+++ b/app/Quote/Rfq.inc.php
@@ -70,6 +70,7 @@ class Rfq {
   private $sheet_sync_status;
   private $sheet_sync_at;
   private $sheet_row;
+  private $sync_to_sheet;
   private $site_visit;
   private $resumes;
   private $qa_deadline;
@@ -147,6 +148,9 @@ class Rfq {
     $this->sheet_sync_status = $row['sheet_sync_status'] ?? null;
     $this->sheet_sync_at = $row['sheet_sync_at'] ?? null;
     $this->sheet_row = $row['sheet_row'] ?? null;
+    // Explicit per-quote pipeline-sync flag. Defaults to 1 to match the column default
+    // for rows created/read before this property is set (e.g. hand-built Rfq arrays).
+    $this->sync_to_sheet = isset($row['sync_to_sheet']) ? (int)$row['sync_to_sheet'] : 1;
     $this->site_visit = isset($row['site_visit']) ? (int)$row['site_visit'] : null;
     $this->resumes = isset($row['resumes']) ? (int)$row['resumes'] : null;
     $this->qa_deadline = $row['qa_deadline'] ?? null;
@@ -708,6 +712,10 @@ class Rfq {
 
   public function getSheetRow() {
     return $this->sheet_row;
+  }
+
+  public function getSyncToSheet() {
+    return $this->sync_to_sheet;
   }
 
   public function getSheetStatus() {

--- a/app/Quote/SheetSyncRepository.inc.php
+++ b/app/Quote/SheetSyncRepository.inc.php
@@ -18,6 +18,21 @@ class SheetSyncRepository {
     }
   }
 
+  // Toggle the explicit per-quote "sync to pipeline" flag. This is the gate that decides
+  // whether edits auto-sync (see save_information.php); the Sync to Sheet / Break Sync
+  // buttons flip it on/off.
+  public static function setSyncToSheet($connection, $id_rfq, $flag) {
+    try {
+      $sql = 'UPDATE rfq SET sync_to_sheet = :flag WHERE id = :id';
+      $stmt = $connection->prepare($sql);
+      $stmt->bindValue(':flag', $flag ? 1 : 0, PDO::PARAM_INT);
+      $stmt->bindValue(':id', $id_rfq, PDO::PARAM_INT);
+      $stmt->execute();
+    } catch (PDOException $ex) {
+      error_log('SheetSyncRepository::setSyncToSheet error: ' . $ex->getMessage());
+    }
+  }
+
   public static function clearSheetRow($connection, $id_rfq) {
     try {
       $sql = 'UPDATE rfq SET sheet_row = NULL WHERE id = :id';

--- a/app/Quote/SheetSyncService.inc.php
+++ b/app/Quote/SheetSyncService.inc.php
@@ -6,6 +6,12 @@ class SheetSyncService {
       . '/workbook/worksheets/' . rawurlencode(GRAPH_SHEET_NAME) . $suffix;
   }
 
+  // Columns the app owns and rewrites on every sync. Everything NOT listed here is
+  // human-owned (E STATUS, I TYPE, K TEAMING PARTNER, O LETTER OF INTENT, P RECRUITMENT,
+  // R SUBMIT BY, S PRICING) and is preserved via read-merge-write — see mergeAppOwned().
+  // 0-based indices: A=0 B=1 C=2 D=3 F=5 G=6 H=7 J=9 L=11 M=12 N=13 Q=16 T=19.
+  private static $humanOwnedIndices = [4, 8, 10, 14, 15, 17, 18]; // E, I, K, O, P, R, S
+
   private static function buildRowValues(Rfq $quote, $designatedUsername) {
     $endDateRaw  = $quote->obtener_end_date() ?? '';
     $endParts    = explode(' ', $endDateRaw, 2);
@@ -17,23 +23,39 @@ class SheetSyncService {
       $quote->getVehicleForSheet(),   // B: VEHICLE
       $quote->obtener_email_code(),   // C: ID
       $quote->getName() ?? '',        // D: (opportunity name)
-      $quote->getSheetStatus(),       // E: STATUS
+      '',                             // E: STATUS (human-owned — preserved on merge)
       $quote->getInternalDueDate() ? date('m/d/Y', strtotime($quote->getInternalDueDate())) : '', // F: INTERNAL DUE DATE
       $endDate,                       // G: CLIENT DUE DATE
       $endTime,                       // H: DUE TIME
-      '',                             // I: TYPE (manual)
+      '',                             // I: TYPE (human-owned)
       $quote->obtener_type_of_bid() ?? '', // J: CATEGORY
-      '',                             // K: TEAMING PARTNER (manual)
+      '',                             // K: TEAMING PARTNER (human-owned)
       is_null($quote->getQa()) ? '' : ($quote->getQa() ? 'YES' : 'NO'), // L: Q&A
       $quote->getQaDeadline() ? date('m/d/Y', strtotime($quote->getQaDeadline())) : '', // M: Q & A DEADLINE
       is_null($quote->getResumes()) ? '' : ($quote->getResumes() ? 'YES' : 'NO'), // N: RESUMES
-      '',                             // O: LETTER OF INTENT (manual)
-      '',                             // P: RECRUITMENT (manual)
+      '',                             // O: LETTER OF INTENT (human-owned)
+      '',                             // P: RECRUITMENT (human-owned)
       is_null($quote->getSiteVisit()) ? '' : ($quote->getSiteVisit() ? 'YES' : 'NO'), // Q: SITE VISIT
-      '',                             // R: SUBMIT BY (manual)
-      '',                             // S: PRICING (manual)
+      '',                             // R: SUBMIT BY (human-owned)
+      '',                             // S: PRICING (human-owned)
       $designatedUsername,            // T: PROPOSAL WRITER
     ];
+  }
+
+  // Read the full A:T values of a sheet row (or [] if it doesn't exist / is empty).
+  private static function readRow($rowIndex) {
+    $resp = GraphApiClient::get(self::wsPath('/range(address=\'' . self::rowAddress($rowIndex) . '\')?$select=values'));
+    return $resp['values'][0] ?? [];
+  }
+
+  // Overlay app-owned values onto the existing row so human-owned cells survive the write.
+  // $existing is whatever Graph currently holds for that row ([] for a brand-new row, in
+  // which case the human-owned cells stay blank).
+  private static function mergeAppOwned(array $appValues, array $existing) {
+    foreach (self::$humanOwnedIndices as $idx) {
+      $appValues[$idx] = $existing[$idx] ?? '';
+    }
+    return $appValues;
   }
 
   private static function getUsedRange() {
@@ -77,6 +99,11 @@ class SheetSyncService {
     $existingRow = self::findRowByQuoteId($quote->obtener_id(), $range['values']);
     $targetRow   = $existingRow ?? ($range['rowCount'] + 1);
 
+    // When overwriting an existing row, read it first so human-owned columns survive.
+    // A genuinely new (appended) row has no existing values, so those cells stay blank.
+    $existingValues = $existingRow ? self::readRow($targetRow) : [];
+    $values = self::mergeAppOwned($values, $existingValues);
+
     GraphApiClient::patch(self::wsPath('/range(address=\'' . self::rowAddress($targetRow) . '\')'), [
       'values' => [$values],
     ]);
@@ -95,15 +122,18 @@ class SheetSyncService {
     // occupies it — re-resolve via appendRow() (which scans column A and overwrites the
     // real row, or appends if it's genuinely gone) and return the corrected row so the
     // caller can persist it.
-    $quoteId = (string)$quote->obtener_id();
-    $cellA   = GraphApiClient::get(self::wsPath('/range(address=\'A' . (int)$sheetRow . '\')?$select=values'));
-    $cellVal = $cellA['values'][0][0] ?? null;
+    // Read the whole row up front: column A (index 0) verifies the pointer, and the rest
+    // supplies the human-owned cell values to preserve on write.
+    $quoteId  = (string)$quote->obtener_id();
+    $existing = self::readRow($sheetRow);
+    $cellVal  = $existing[0] ?? null;
     if ($cellVal === null || (string)$cellVal !== $quoteId) {
       return self::appendRow($quote, $designatedUsername);
     }
 
+    $values = self::mergeAppOwned(self::buildRowValues($quote, $designatedUsername), $existing);
     GraphApiClient::patch(self::wsPath('/range(address=\'' . self::rowAddress($sheetRow) . '\')'), [
-      'values' => [self::buildRowValues($quote, $designatedUsername)],
+      'values' => [$values],
     ]);
 
     return $sheetRow;

--- a/css/estilos.css
+++ b/css/estilos.css
@@ -2682,3 +2682,77 @@ h3.text-info.text-center .fa-exclamation-circle {
   color: #7d8ba0;
   font-weight: 500;
 }
+
+/* Sync to pipeline — inline checkbox field (New Quote form) */
+.sync-field {
+  padding-top: 2px;
+}
+.sync-check {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-bottom: 0;
+  cursor: pointer;
+  user-select: none;
+  position: relative;
+  font-weight: 400;
+}
+.sync-check-input {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  margin: 0;
+  pointer-events: none;
+}
+.sync-check-box {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  margin-top: 1px;
+  border: 1.5px solid #aab4c2;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #ffffff;
+  display: grid;
+  place-items: center;
+  transition: background-color 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
+}
+.sync-check-box > svg {
+  width: 13px;
+  height: 13px;
+  opacity: 0;
+  transform: scale(0.4);
+  transition: opacity 0.16s ease, transform 0.2s cubic-bezier(0.2, 1.4, 0.5, 1);
+}
+.sync-check:hover .sync-check-box {
+  border-color: #2db4e8;
+}
+.sync-check-input:checked + .sync-check-box {
+  background: #2db4e8;
+  border-color: #2db4e8;
+}
+.sync-check-input:checked + .sync-check-box > svg {
+  opacity: 1;
+  transform: scale(1);
+}
+.sync-check-input:focus-visible + .sync-check-box {
+  box-shadow: 0 0 0 3px rgba(45, 180, 232, 0.25);
+}
+.sync-check-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.sync-check-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: #0f1623;
+  line-height: 1.35;
+}
+.sync-check-help {
+  font-size: 11.5px;
+  color: #5a6a7e;
+  line-height: 1.4;
+}

--- a/forms/quote/registro_cotizacion_vacio.inc.php
+++ b/forms/quote/registro_cotizacion_vacio.inc.php
@@ -33,6 +33,24 @@
   </div>
 
   <div class="form-row">
+    <div class="col-md-6 d-none d-md-block"></div>
+    <div class="col-md-6">
+      <div class="form-group sync-field">
+        <label class="sync-check" for="sync_to_sheet">
+          <input type="checkbox" class="sync-check-input" id="sync_to_sheet" name="sync_to_sheet" value="1" checked>
+          <span class="sync-check-box" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+          </span>
+          <span class="sync-check-text">
+            <span class="sync-check-label">Sync to pipeline</span>
+            <span class="sync-check-help">Adds this quote to the E-LOGIC Bid Pipeline sheet.</span>
+          </span>
+        </label>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-row">
     <div class="col-md-6">
       <div class="form-group">
         <label for="issue_date">Issue Date</label>
@@ -125,7 +143,7 @@
     <select id="create_master_proposal" name="multi_year_project" class="form-control form-control-sm" style="width:100%;">
       <option value="">None — this is a standalone proposal</option>
     </select>
-    <small class="form-text text-muted">Link this as a child of a multi-year project. Child quotes are <strong>not synced</strong> to the sheet.</small>
+    <small class="form-text text-muted">Link this as a child of a multi-year project.</small>
   </div>
 
   <div class="form-group">

--- a/forms/quote/registro_cotizacion_validado.inc.php
+++ b/forms/quote/registro_cotizacion_validado.inc.php
@@ -38,6 +38,24 @@
   </div>
 
   <div class="form-row">
+    <div class="col-md-6 d-none d-md-block"></div>
+    <div class="col-md-6">
+      <div class="form-group sync-field">
+        <label class="sync-check" for="sync_to_sheet">
+          <input type="checkbox" class="sync-check-input" id="sync_to_sheet" name="sync_to_sheet" value="1" <?= isset($_POST['sync_to_sheet']) ? 'checked' : ''; ?>>
+          <span class="sync-check-box" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+          </span>
+          <span class="sync-check-text">
+            <span class="sync-check-label">Sync to pipeline</span>
+            <span class="sync-check-help">Adds this quote to the E-LOGIC Bid Pipeline sheet.</span>
+          </span>
+        </label>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-row">
     <div class="col-md-6">
       <div class="form-group">
         <label for="issue_date">Issue Date</label>
@@ -137,7 +155,7 @@
         <option value="<?= (int)$_POST['multi_year_project']; ?>" selected>Proposal #<?= (int)$_POST['multi_year_project']; ?></option>
       <?php endif; ?>
     </select>
-    <small class="form-text text-muted">Link this as a child of a multi-year project. Child quotes are <strong>not synced</strong> to the sheet.</small>
+    <small class="form-text text-muted">Link this as a child of a multi-year project.</small>
   </div>
 
   <div class="form-group">

--- a/plantillas/quote/editar_cotizacion.inc.php
+++ b/plantillas/quote/editar_cotizacion.inc.php
@@ -49,7 +49,6 @@ if (is_null($cotizacion_recuperada)) {
   </div>
 
   <?php
-  $ss_is_child  = $cotizacion_recuperada->obtener_multi_year_project() !== null;
   $ss_status    = $cotizacion_recuperada->getSheetSyncStatus();
   $ss_at        = $cotizacion_recuperada->getSheetSyncAt();
   $ss_opp       = $cotizacion_recuperada->getName();
@@ -67,19 +66,6 @@ if (is_null($cotizacion_recuperada)) {
   ];
   ?>
   <div class="container-fluid" style="padding-top:14px;padding-bottom:0;">
-    <?php if ($ss_is_child): ?>
-      <div class="ss-block ss-block-never" style="justify-content:flex-start;gap:10px;">
-        <div class="ss-block-icon ss-block-icon-never">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
-        </div>
-        <div class="ss-block-body">
-          <div class="ss-block-label">Sheet Sync</div>
-          <div class="ss-block-status-row">
-            <span class="ss-block-status ss-block-status-never">Child quotes are not synced to the sheet.</span>
-          </div>
-        </div>
-      </div>
-    <?php else: ?>
       <div id="ss-block" class="ss-block ss-block-<?= htmlspecialchars($ss_tone); ?>"
            data-id="<?= (int)$id_rfq; ?>">
         <div class="ss-block-icon ss-block-icon-<?= htmlspecialchars($ss_tone); ?>">
@@ -125,7 +111,6 @@ if (is_null($cotizacion_recuperada)) {
           </button>
         </div>
       </div>
-    <?php endif; ?>
   </div>
 
   <section class="content" style="padding-top:20px;">

--- a/plantillas/quote/nueva_cotizacion.inc.php
+++ b/plantillas/quote/nueva_cotizacion.inc.php
@@ -57,5 +57,17 @@ $(function () {
     },
     minimumInputLength: 1
   });
+
+  // Sync to pipeline — auto-set the checkbox default from the chosen Type of Bid.
+  // Service-type commodities sync by default; hardware/VAR types do not. The user can
+  // still flip the checkbox afterward (we only re-set it when the bid type changes).
+  var SYNCABLE_BID_TYPES = [
+    'MOVING & LOGISTICS', 'PROFESSIONAL SERVICES', 'IT',
+    'Audio Visual', 'A/V', 'A/V - INSTALLATION', 'A/V - SERVICES', 'Services'
+  ];
+  $('#type_of_bid').on('change', function () {
+    var isSyncable = SYNCABLE_BID_TYPES.indexOf($(this).val()) !== -1;
+    $('#sync_to_sheet').prop('checked', isSyncable);
+  });
 });
 </script>

--- a/plantillas/quote/validacion_registro_cotizacion.inc.php
+++ b/plantillas/quote/validacion_registro_cotizacion.inc.php
@@ -96,6 +96,7 @@ function createAndInsertQuote($validador, $usuario_designado) {
     'reference_url' => Input::test_input($_POST["reference_url"]),
     'priority' => isset($_POST['priority_level']) ? $_POST['priority_level'] : null,
     'name' => !empty($_POST['name']) ? htmlspecialchars(trim($_POST['name']), ENT_QUOTES, 'UTF-8') : null,
+    'sync_to_sheet'    => isset($_POST['sync_to_sheet']) ? 1 : 0,
     'site_visit'       => isset($_POST['site_visit'])  && $_POST['site_visit']  !== '' ? (int)$_POST['site_visit']  : null,
     'resumes'          => isset($_POST['resumes'])     && $_POST['resumes']     !== '' ? (int)$_POST['resumes']     : null,
     'qa_deadline'      => !empty($_POST['qa_deadline'])      ? $_POST['qa_deadline']      : null,
@@ -109,9 +110,10 @@ function createAndInsertQuote($validador, $usuario_designado) {
   // Log audit trails
   logAuditTrails($id_rfq, $validador);
 
-  // Auto-sync to SharePoint sheet for qualifying bid types
-  $syncable_bid_types = ['Audio Visual', 'Services'];
-  if ($cotizacion_insertada && in_array($_POST['type_of_bid'], $syncable_bid_types) && empty($_POST['multi_year_project'])) {
+  // Auto-sync to the SharePoint sheet when the user opted in via the "Sync to pipeline"
+  // checkbox. The checkbox is the sole gate — bid type only sets its default in the form,
+  // and master-linked (child) quotes may sync too.
+  if ($cotizacion_insertada && isset($_POST['sync_to_sheet'])) {
     try {
       $designatedUsername = $_POST['usuario_designado'];
       $insertedQuote = RepositorioRfq::obtener_cotizacion_por_id(Conexion::obtener_conexion(), $id_rfq);

--- a/scripts/quote/break_sheet_sync.php
+++ b/scripts/quote/break_sheet_sync.php
@@ -22,8 +22,10 @@ try {
   // (see the Break Sync modal copy), and retaining the pointer means a future manual
   // "Sync to Sheet" re-attaches to that exact row via syncRow() instead of taking the
   // appendRow() path — which decides append-vs-update by scanning the eventually-consistent
-  // sheet and can miss the orphaned row, creating a duplicate. Auto-sync is gated on the
-  // status (see save_information.php), so flipping status to 'never' is enough to stop it.
+  // sheet and can miss the orphaned row, creating a duplicate.
+  // Turn the per-quote flag off so edits stop auto-syncing (the gate in save_information.php),
+  // and flip the status to 'never' for the UI badge.
+  SheetSyncRepository::setSyncToSheet($conexion, $id_rfq, 0);
   SheetSyncRepository::updateSyncStatus($conexion, $id_rfq, 'never');
 
   Conexion::cerrar_conexion();

--- a/scripts/quote/guardar_editar_cotizacion.php
+++ b/scripts/quote/guardar_editar_cotizacion.php
@@ -94,25 +94,11 @@ if (isset($_POST['guardar_cambios_cotizacion'])) {
 
     Conexion::cerrar_conexion();
 
-    // Helper: update the sheet STATUS cell after a status transition (skips child quotes)
-    $updateSheetStatus = function($id, $sheetRow, $newStatus) use ($cotizacion_recuperada) {
-      if ($cotizacion_recuperada->obtener_multi_year_project() !== null) {
-        return;
-      }
-      try {
-        if ($sheetRow) {
-          SheetSyncService::updateStatusCell($sheetRow, $newStatus);
-          Conexion::abrir_conexion();
-          SheetSyncRepository::updateSyncStatus(Conexion::obtener_conexion(), $id, 'synced');
-          Conexion::cerrar_conexion();
-        }
-      } catch (Exception $syncEx) {
-        error_log('Sheet sync error on status update: ' . $syncEx->getMessage());
-        Conexion::abrir_conexion();
-        SheetSyncRepository::updateSyncStatus(Conexion::obtener_conexion(), $id, 'failed');
-        Conexion::cerrar_conexion();
-      }
-    };
+    // Status transitions no longer push to the sheet's STATUS column (col E is human-owned —
+    // staff edit it directly in the sheet and a write would wipe their changes). The lifecycle
+    // status lives in the app; app-owned columns sync via the Save Information flow instead.
+    // Kept as a no-op so the status-transition branches below don't need to change.
+    $updateSheetStatus = function($id, $sheetRow, $newStatus) { /* STATUS is human-owned */ };
 
     if ($cotizacion_recuperada->obtener_canal() == 'Chemonics' && $award === 'si') {
       Conexion::abrir_conexion();

--- a/scripts/quote/save_information.php
+++ b/scripts/quote/save_information.php
@@ -48,24 +48,25 @@ if (isset($_POST['save_information'])) {
       SheetSyncRepository::updateNameAndResetSync($conexion, $_POST['id_rfq'], trim($_POST['name']));
     }
 
-    // Auto-sync to SharePoint sheet for qualifying bid types
-    $syncable_bid_types = ['Audio Visual', 'Services'];
-    if (in_array($_POST['type_of_bid'], $syncable_bid_types)) {
-      try {
-        $updatedQuote = RepositorioRfq::obtener_cotizacion_por_id($conexion, $_POST['id_rfq']);
-        // Gate auto-sync on the sync STATUS, not merely on having a sheet_row. After a
-        // "Break Sync" the pointer is retained (so manual re-sync re-attaches cleanly) but
-        // the status is 'never', and edits must NOT silently push to the sheet.
-        if ($updatedQuote && $updatedQuote->obtener_multi_year_project() === null
-            && $updatedQuote->getSheetSyncStatus() === 'synced' && $updatedQuote->getSheetRow()) {
-          $designatedUsername = $_POST['usuario_designado'];
+    // Auto-sync to the SharePoint sheet whenever this quote is flagged to sync.
+    // The sync_to_sheet flag is the sole gate — bid type and master-link no longer matter.
+    // "Break Sync" sets the flag to 0 (keeping sheet_row), so edits then stop pushing.
+    try {
+      $updatedQuote = RepositorioRfq::obtener_cotizacion_por_id($conexion, $_POST['id_rfq']);
+      if ($updatedQuote && (int)$updatedQuote->getSyncToSheet() === 1) {
+        $designatedUsername = $_POST['usuario_designado'];
+        if ($updatedQuote->getSheetRow()) {
+          // syncRow self-heals a stale pointer and returns the row it actually wrote.
           $writtenRow = SheetSyncService::syncRow($updatedQuote->getSheetRow(), $updatedQuote, $designatedUsername);
-          SheetSyncRepository::updateSyncStatus($conexion, $_POST['id_rfq'], 'synced', $writtenRow);
+        } else {
+          // Flagged to sync but no row yet (e.g. a prior append failed) — append (dedup-safe).
+          $writtenRow = SheetSyncService::appendRow($updatedQuote, $designatedUsername);
         }
-      } catch (Exception $syncEx) {
-        SheetSyncRepository::updateSyncStatus($conexion, $_POST['id_rfq'], 'failed');
-        error_log('Sheet sync error on information save: ' . $syncEx->getMessage());
+        SheetSyncRepository::updateSyncStatus($conexion, $_POST['id_rfq'], 'synced', $writtenRow);
       }
+    } catch (Exception $syncEx) {
+      SheetSyncRepository::updateSyncStatus($conexion, $_POST['id_rfq'], 'failed');
+      error_log('Sheet sync error on information save: ' . $syncEx->getMessage());
     }
 
     // Log information events

--- a/scripts/quote/sync_to_sheet.php
+++ b/scripts/quote/sync_to_sheet.php
@@ -26,12 +26,6 @@ try {
     exit;
   }
 
-  if ($quote->obtener_multi_year_project() !== null) {
-    Conexion::cerrar_conexion();
-    echo json_encode(['success' => false, 'message' => 'Child quotes are not synced to the sheet.']);
-    exit;
-  }
-
   $usuario = RepositorioUsuario::obtener_usuario_por_id($conexion, $quote->obtener_usuario_designado());
   $designatedUsername = $usuario ? $usuario->obtener_nombre_usuario() : '';
 
@@ -48,6 +42,8 @@ try {
 
   Conexion::abrir_conexion();
   SheetSyncRepository::updateSyncStatus(Conexion::obtener_conexion(), $id_rfq, 'synced', $sheetRow);
+  // Manually syncing also turns the per-quote flag on, so future edits auto-sync.
+  SheetSyncRepository::setSyncToSheet(Conexion::obtener_conexion(), $id_rfq, 1);
   $syncAt = date('M j, Y \a\t g:i A');
   Conexion::cerrar_conexion();
 

--- a/sql/pipeline_sync_controls_migration.sql
+++ b/sql/pipeline_sync_controls_migration.sql
@@ -1,0 +1,8 @@
+-- Bid Pipeline Sync Controls migration
+-- Adds an explicit per-quote "sync to pipeline" flag. Existing rows default to 1,
+-- which closely matches the previous "eligible bid types sync" behavior; any quote
+-- that should not sync can be turned off with the Break Sync button.
+-- Run once on each environment (local, staging, production).
+
+ALTER TABLE rfq
+  ADD COLUMN sync_to_sheet TINYINT(1) NOT NULL DEFAULT 1;


### PR DESCRIPTION
Implements the **Quote Form New Fields** design handoff (the "Sync to pipeline" checkbox) as the planned **Bid Pipeline Sync Controls** feature. The three "Additional Requirements" fields shown in the same mockup were already built and are unchanged.

## What changed

**Explicit per-quote sync flag**
- New `rfq.sync_to_sheet` column (`TINYINT(1) NOT NULL DEFAULT 1`; existing rows backfill to `1`). It is now the **sole auto-sync gate** — bid type and master/child link no longer decide whether a quote syncs.

**New Quote form**
- "Sync to pipeline" checkbox under Type of Bid (+ helper line *"Adds this quote to the E-LOGIC Bid Pipeline sheet."*).
- JS smart-defaults the checkbox from the selected bid type (all A/V variants + `IT` / `MOVING & LOGISTICS` / `PROFESSIONAL SERVICES` / `Services`), fully user-overridable. Applied to both the empty and post-validation form variants.

**Post-creation toggle (no new control)**
- `Sync to Sheet` button → flag = 1 (and syncs now); `Break Sync` → flag = 0 (keeps `sheet_row`).
- `copyRfq` sets copies to `0` so multi-year duplicates don't flood the pipeline.

**Edit page**
- Removed the "Child quotes are not synced to the sheet" special state — master-linked quotes now show the standard Sheet Sync block.

**Column ownership (read-merge-write)**
- App rewrites `A,B,C,D,F,G,H,J,L,M,N,Q,T` each sync; **`E` (STATUS), `I`, `K`, `O`, `P`, `R`, `S` are human-owned** and preserved (blank on brand-new rows).
- Status transitions in `guardar_editar_cotizacion.php` no longer push the STATUS cell.

## Migration

Run once per environment (already applied to local dev):
```
sql/pipeline_sync_controls_migration.sql
```

## Testing
- `php -l` clean on all 15 changed PHP files.
- Focused PHP logic test: `getSyncToSheet()` defaults to `1` when absent; `mergeAppOwned` preserves the 7 human columns while writing app columns (and leaves human cells blank on new rows).
- Migration applied locally; 55,513 existing rows backfilled to `sync_to_sheet = 1`.
- Note: the live Microsoft Graph round-trip was **not** exercised (it writes to production SharePoint) — recommend a smoke test in a safe environment confirming a human-typed value in E/I/K/O/P/R/S survives a save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)