### PR TITLE
fix: align service-eligible bid types with pipeline sync list

### DIFF
--- a/app/Quote/Rfq.inc.php
+++ b/app/Quote/Rfq.inc.php
@@ -468,7 +468,13 @@ class Rfq {
   }
 
   public function isServices() {
-    $services = ['Services', 'Audio Visual', 'Computers', 'Back Up Batteries'];
+    // Keep in step with SYNCABLE_BID_TYPES in plantillas/quote/nueva_cotizacion.inc.php.
+    // The sync list plus the two legacy service-eligible types (Computers, Back Up Batteries).
+    $services = [
+      'Services', 'Audio Visual', 'Computers', 'Back Up Batteries',
+      'MOVING & LOGISTICS', 'PROFESSIONAL SERVICES', 'IT',
+      'A/V', 'A/V - INSTALLATION', 'A/V - SERVICES'
+    ];
     if (in_array($this->type_of_bid, $services)) {
       return true;
     }


### PR DESCRIPTION
## Problem

Two bid-type lists had drifted apart:

- **`SYNCABLE_BID_TYPES`** (`plantillas/quote/nueva_cotizacion.inc.php`) — gates pipeline sheet sync.
- **`isServices()`** (`app/Quote/Rfq.inc.php`) — gates the **Services** section in the quote editor, plus services in fulfillment, proposals, and re-quote.

A quote whose bid type synced to the sheet (`MOVING & LOGISTICS`, `PROFESSIONAL SERVICES`, `IT`, `A/V`, `A/V - INSTALLATION`, `A/V - SERVICES`) could **not** create services, because `isServices()` didn't recognize those types.

## Fix

`isServices()` now returns the **union** of the sync list and the two legacy service-eligible types (`Computers`, `Back Up Batteries`):

`Services`, `Audio Visual`, `Computers`, `Back Up Batteries`, `MOVING & LOGISTICS`, `PROFESSIONAL SERVICES`, `IT`, `A/V`, `A/V - INSTALLATION`, `A/V - SERVICES`

- Nothing that was service-eligible before loses access (legacy types kept).
- All pipeline-sync bid types can now create services.
- A comment points back to `SYNCABLE_BID_TYPES` so the two lists stay in step.

## Notes

The two lists are still hardcoded separately (PHP vs JS) and can drift again. A follow-up could have PHP emit the canonical list to the page as a single source of truth.

Linted clean: `docker exec lamp-php83 php -l ...Rfq.inc.php` → no syntax errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)