### PR TITLE
Make INTERNAL DUE DATE (col F) human-owned in sheet sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ The DB column `rfq.sheet_row` is the source of truth for which sheet row a quote
 - `appendRow` reads row-count + column A to find/append; before overwriting an existing row it reads that row's `A:T` so human columns survive.
 - After `deleteRow` (shift='Up'), call `SheetSyncRepository::shiftRowsAfterDelete()` to decrement pointers below the deleted row.
 - **Per-quote `sync_to_sheet` flag is the sole auto-sync gate** (not bid type, not child/master-link). Creation form's "Sync to pipeline" checkbox sets it (JS smart-defaults it from bid type via the syncable list — all A/V variants + `IT`/`MOVING & LOGISTICS`/`PROFESSIONAL SERVICES`/`Services` — but the user can override). `Sync to Sheet` btn sets flag=1 (+status `synced`); `Break Sync` sets flag=0 (keeps `sheet_row`, status `never`). `copyRfq` sets copies to 0.
-- **Read-merge-write column ownership** (`SheetSyncService::mergeAppOwned`): app rewrites A,B,C,D,F,G,H,J,L,M,N,Q,T each sync; **E (STATUS), I, K, O, P, R, S are human-owned** and preserved (blank on brand-new rows). Status transitions in `guardar_editar_cotizacion.php` no longer push STATUS (that helper is now a no-op).
+- **Read-merge-write column ownership** (`SheetSyncService::mergeAppOwned`): app rewrites A,B,C,D,G,H,J,L,M,N,Q,T each sync; **E (STATUS), F (INTERNAL DUE DATE), I, K, O, P, R, S are human-owned** and preserved (blank on brand-new rows). Status transitions in `guardar_editar_cotizacion.php` no longer push STATUS (that helper is now a no-op).
 
 ### Unified Audit Trail
 

--- a/app/Quote/SheetSyncService.inc.php
+++ b/app/Quote/SheetSyncService.inc.php
@@ -7,10 +7,11 @@ class SheetSyncService {
   }
 
   // Columns the app owns and rewrites on every sync. Everything NOT listed here is
-  // human-owned (E STATUS, I TYPE, K TEAMING PARTNER, O LETTER OF INTENT, P RECRUITMENT,
-  // R SUBMIT BY, S PRICING) and is preserved via read-merge-write — see mergeAppOwned().
-  // 0-based indices: A=0 B=1 C=2 D=3 F=5 G=6 H=7 J=9 L=11 M=12 N=13 Q=16 T=19.
-  private static $humanOwnedIndices = [4, 8, 10, 14, 15, 17, 18]; // E, I, K, O, P, R, S
+  // human-owned (E STATUS, F INTERNAL DUE DATE, I TYPE, K TEAMING PARTNER, O LETTER OF
+  // INTENT, P RECRUITMENT, R SUBMIT BY, S PRICING) and is preserved via read-merge-write —
+  // see mergeAppOwned().
+  // 0-based indices: A=0 B=1 C=2 D=3 G=6 H=7 J=9 L=11 M=12 N=13 Q=16 T=19.
+  private static $humanOwnedIndices = [4, 5, 8, 10, 14, 15, 17, 18]; // E, F, I, K, O, P, R, S
 
   private static function buildRowValues(Rfq $quote, $designatedUsername) {
     $endDateRaw  = $quote->obtener_end_date() ?? '';
@@ -24,7 +25,7 @@ class SheetSyncService {
       $quote->obtener_email_code(),   // C: ID
       $quote->getName() ?? '',        // D: (opportunity name)
       '',                             // E: STATUS (human-owned — preserved on merge)
-      $quote->getInternalDueDate() ? date('m/d/Y', strtotime($quote->getInternalDueDate())) : '', // F: INTERNAL DUE DATE
+      '',                             // F: INTERNAL DUE DATE (human-owned — preserved on merge)
       $endDate,                       // G: CLIENT DUE DATE
       $endTime,                       // H: DUE TIME
       '',                             // I: TYPE (human-owned)


### PR DESCRIPTION
## Summary

Makes the **INTERNAL DUE DATE** column (`F`) on the E-LOGIC BID PIPELINE sheet fully human-owned, keeping it independent from the app.

Previously the app rewrote column F from the quote's `internal_due_date` on every sync, clobbering any manual edits in the sheet. Now F behaves like the other human-owned columns (STATUS, TYPE, etc.): the app never writes it and `mergeAppOwned()` preserves whatever the sheet holds.

## Changes

- `app/Quote/SheetSyncService.inc.php`
  - Added index `5` (col F) to `$humanOwnedIndices` → `[4, 5, 8, 10, 14, 15, 17, 18]`
  - Changed the F entry in `buildRowValues()` from the computed `getInternalDueDate()` value to `''`, matching the other human-owned columns
  - Updated the ownership comment block
- `CLAUDE.md` — updated the documented column ownership note

## Behavior

- **Existing rows:** manual edits to INTERNAL DUE DATE survive every sync (read-merge-write preserves the cell).
- **Brand-new appended rows:** F starts blank, same as STATUS/TYPE/etc.
- The quote's `internal_due_date` DB field is unchanged — it's still captured and stored, just no longer pushed to the sheet.

## Testing

- `php -l` passes on the modified file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)