### PR TITLE
fix: correct Net 30/CC multiplier and total rounding for services

### DIFF
--- a/js/quote.js
+++ b/js/quote.js
@@ -105,7 +105,7 @@ $(document).ready(function () {
     $('#total_additional').html(`$ ${totalAdditional.toFixed(2)}`);
 
     // Services calculation — runs in the same tick so the total feeds into the bottom bar
-    const svcPaymentMultiplier = $('input:radio[name=services_payment_term]:checked').val() === 'Net 30/CC' ? 1.0299 : 1;
+    const svcPaymentMultiplier = $('input:radio[name=services_payment_term]:checked').val() === 'Net 30/CC' ? 1.03 : 1;
     let totalServices = 0;
     $('#services_table tbody .service_item').each(function () {
       const $cells = $(this).find('td');
@@ -114,7 +114,7 @@ $(document).ready(function () {
       if (!$unitCell.data('base-price')) $unitCell.data('base-price', basePrice);
       const qty = parseFloat($cells.eq(3).text()) || 0;
       const newUnitPrice = (basePrice * svcPaymentMultiplier).toFixed(2);
-      const newTotalPrice = (newUnitPrice * qty).toFixed(2);
+      const newTotalPrice = (basePrice * svcPaymentMultiplier * qty).toFixed(2);
       totalServices += parseFloat(newTotalPrice);
       $unitCell.html(newUnitPrice);
       $cells.eq(5).html(newTotalPrice);


### PR DESCRIPTION
## Summary

- Fix `svcPaymentMultiplier` from `1.0299` to `1.03` so it matches the PHP-side `calc_items_with_CC` and `print_service` multipliers
- Compute displayed service total from `basePrice * multiplier * qty` (precise) instead of `newUnitPrice * qty` (from already-rounded unit price), preventing rounding errors that scale with quantity

## Root cause

For Net 30/CC quotes with services, the app was using `1.0299` while the DB and PDF both use `1.03`. Additionally, the total was recomputed from the truncated 2-decimal unit price instead of the precise base, causing visible discrepancies on high-quantity lines (e.g. item with qty=500 showed $3,335.00 in the app vs $3,337.20 in the proposal PDF).

## Test plan

- [ ] Open a services quote with payment term Net 30/CC
- [ ] Toggle between Net 30 and Net 30/CC and confirm unit prices and totals update correctly
- [ ] Generate a proposal PDF and confirm the totals now match the app display

🤖 Generated with [Claude Code](https://claude.com/claude-code)