### PR TITLE
fix: round service unit price before multiplying by qty for CC total

### DIFF
--- a/app/Service/ServiceRepository.inc.php
+++ b/app/Service/ServiceRepository.inc.php
@@ -250,7 +250,7 @@ class ServiceRepository {
     $payment_term = $payment_term == 'Net 30/CC' ? 1.03 : 1;
     if (isset($connection)) {
       try {
-        $sql = 'UPDATE services SET total_price = quantity * (unit_price * :payment_term) WHERE id_rfq = :id_rfq';
+        $sql = 'UPDATE services SET total_price = quantity * ROUND(unit_price * :payment_term, 2) WHERE id_rfq = :id_rfq';
         $sentence = $connection->prepare($sql);
         $sentence->bindValue(':id_rfq', $id_rfq, PDO::PARAM_STR);
         $sentence->bindValue(':payment_term', $payment_term, PDO::PARAM_STR);

--- a/js/quote.js
+++ b/js/quote.js
@@ -114,7 +114,7 @@ $(document).ready(function () {
       if (!$unitCell.data('base-price')) $unitCell.data('base-price', basePrice);
       const qty = parseFloat($cells.eq(3).text()) || 0;
       const newUnitPrice = (basePrice * svcPaymentMultiplier).toFixed(2);
-      const newTotalPrice = (basePrice * svcPaymentMultiplier * qty).toFixed(2);
+      const newTotalPrice = (parseFloat(newUnitPrice) * qty).toFixed(2);
       totalServices += parseFloat(newTotalPrice);
       $unitCell.html(newUnitPrice);
       $cells.eq(5).html(newTotalPrice);


### PR DESCRIPTION
## Summary

Follow-up to #51. That PR correctly fixed the `1.0299 → 1.03` multiplier, but it computed the service line total from the **full-precision** per-unit price (`unit_price * 1.03`) while the **displayed** unit price is rounded to 2 decimals. The result: `unit × qty` no longer equalled the shown total.

Example (quote 125428, item 3): qty 500, unit displayed `6.67`, but total showed `3337.20` (= `6.6744 × 500`) instead of `3335.00` (= `6.67 × 500`). The error scaled with quantity.

## Change

Round the per-unit CC price to 2 decimals **first**, then multiply by quantity, in both places that produce the total:

- **`js/quote.js`** — live recalc on the quote page (`newTotalPrice = round(unit) × qty`)
- **`app/Service/ServiceRepository.inc.php`** `calc_items_with_CC` — stored `total_price`, which the proposal PDF reads (`quantity * ROUND(unit_price * :payment_term, 2)`)

Now the app and the PDF are internally consistent: `unit × qty = total` on every line.

## Corrected values for quote 125428

| # | Qty | Unit | Total |
|---|---|---|---|
| 3 | 500 | 6.67 | 3,335.00 |
| 5 | 4 | 44.50 | 178.00 |

New services total: **$20,742.84**.

## Note on existing data

`calc_items_with_CC` only runs on save/autosave, so stored totals for existing quotes refresh the next time the quote is saved. To update the PDF for an already-completed quote, re-save it and regenerate the proposal.

## Test plan

- [ ] Open a Net 30/CC services quote with a high-quantity line; confirm `unit × qty == total` on screen
- [ ] Toggle Net 30 ↔ Net 30/CC and confirm unit prices and totals update consistently
- [ ] Save, regenerate the proposal PDF, and confirm the PDF totals match the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)