### PR TITLE
feat: quote lifecycle audit events + Audit Trail Sync tab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 | Bid Pipeline Sync Controls (`sync_to_sheet` flag, bid-type smart default, human-owned sheet columns, master-linked quotes keep syncing) | built | — |
 | Bid Pipeline Metrics Dashboard (interactive ApexCharts report reproducing the SharePoint METRICS 2026 tab from app data) | built | — |
 | 3-Year Annual Awards Comparison (Charts tab annual cards: rolling current + 2 prior years) | built | — |
+| Quote Lifecycle Audit Events (audit-trail entries on quote create / sync / unsync, surfaced via the Audit Trail modal's Sync tab) | built | — |
 
 ## Environment
 
@@ -103,11 +104,11 @@ All three domains write to their own audit table but are surfaced through a sing
 - `app/ReQuote/ReQuoteAuditTrailRepository.inc.php` — same pattern for re-quote
 - `app/Fulfillment/FulfillmentAuditTrailRepository.inc.php` — adds `status_event()`, `invoice_event()`, `net_30_event()` helpers
 
-**Action types** (stored in `action_type` column): `status_change`, `field_modified`, `item_modified`, `item_created`, `item_deleted`, `invoice_created`, `invoice_updated`, `invoice_deleted`, `document_updated`, `net_30`.
+**Action types** (stored in `action_type` column): `status_change`, `field_modified`, `item_modified`, `item_created`, `item_deleted`, `invoice_created`, `invoice_updated`, `invoice_deleted`, `document_updated`, `net_30`, `quote_created` (Status group), `sync_to_sheet`/`break_sync` (Sync group — quote only). The three lifecycle helpers on `AuditTrailRepository` (`quote_created_audit_trail`, `sync_to_sheet_audit_trail`, `break_sync_audit_trail`) mirror `quote_status_audit_trail`; only **successful** syncs are logged (every flagged save logs one — accepted noise, isolated under the Sync tab). Call sites: create (`validacion_registro_cotizacion.inc.php`), all 3 sync paths after a `synced` status (`sync_to_sheet.php`, on-create + on-save auto-sync), and `break_sheet_sync.php`.
 
 **Unified endpoint:** `POST /rfq/quote/load_unified_audit_trail` (`scripts/quote/load_unified_audit_trail.php`) — accepts `id_rfq`, queries all three tables (re-quote joined via `re_quotes.id_rfq`), merges and sorts by `created_date DESC`, returns JSON array. Each entry has: `id, username, action_type, audit_trail, created_date, scope` (scope values: `quote`, `requote`, `fulfillment`).
 
-**Frontend:** `js/audit_trail.js` — self-contained IIFE; handles open/load/filter/render for all three pages. Included in `editar_cotizacion.inc.php`, `fulfillment.inc.php`, and `re_quote.inc.php`. The trigger buttons (`#audit_trails_button`, `#fulfillment_audit_trails_button`) must have `data-id="<id_rfq>"`.
+**Frontend:** `js/audit_trail.js` — self-contained IIFE; handles open/load/filter/render for all three pages. Included in `editar_cotizacion.inc.php`, `fulfillment.inc.php`, and `re_quote.inc.php`. The trigger buttons (`#audit_trails_button`, `#fulfillment_audit_trails_button`) must have `data-id="<id_rfq>"`. Primary filter tabs: All / Status / Edits / Items / Invoices / **Sync**. Sync-group events render as compact single-line rows (`at-sync-*`, purple Synced / amber Unsynced) instead of full cards; 3+ consecutive `sync_to_sheet` events collapse into one expandable "N automatic syncs" run (`at-run-*`, `atBuildUnits`).
 
 **Modal templates** (all identical unified shell, `id="audit_trails_modal"`):
 - `plantillas/quote/modals/audit_trails_modal.inc.php`

--- a/app/Quote/AuditTrailRepository.inc.php
+++ b/app/Quote/AuditTrailRepository.inc.php
@@ -353,6 +353,27 @@ class AuditTrailRepository {
     self::insert_audit_trail($connection, $audit_trail);
   }
 
+  // ---- Quote lifecycle events (creation + Bid Pipeline sheet sync) ----
+  // Each mirrors quote_status_audit_trail: session-derived username/id, one insert_audit_trail row.
+
+  public static function quote_created_audit_trail($connection, $id_rfq) {
+    $message = 'The quote was <b>Created</b>';
+    $audit_trail = new AuditTrail('', $id_rfq, $_SESSION['user']->obtener_nombre_usuario(), 'quote_created', $_SESSION['user']->obtener_id(), $message, '');
+    self::insert_audit_trail($connection, $audit_trail);
+  }
+
+  public static function sync_to_sheet_audit_trail($connection, $id_rfq) {
+    $message = 'Quote synced to <b>Bid Pipeline</b>';
+    $audit_trail = new AuditTrail('', $id_rfq, $_SESSION['user']->obtener_nombre_usuario(), 'sync_to_sheet', $_SESSION['user']->obtener_id(), $message, '');
+    self::insert_audit_trail($connection, $audit_trail);
+  }
+
+  public static function break_sync_audit_trail($connection, $id_rfq) {
+    $message = 'Quote unsynced from <b>Bid Pipeline</b>';
+    $audit_trail = new AuditTrail('', $id_rfq, $_SESSION['user']->obtener_nombre_usuario(), 'break_sync', $_SESSION['user']->obtener_id(), $message, '');
+    self::insert_audit_trail($connection, $audit_trail);
+  }
+
   public static function re_quote_status_audit_trail($connection, $status, $id_rfq) {
     $message = 'The Re-quote was <b>' . $status . '</b>';
     $audit_trail = new AuditTrail('', $id_rfq, $_SESSION['user']->obtener_nombre_usuario(), 'status_change', $_SESSION['user']->obtener_id(), $message, '');

--- a/css/estilos.css
+++ b/css/estilos.css
@@ -1962,6 +1962,61 @@ h3.text-info.text-center .fa-exclamation-circle {
 .at-btn-secondary { background: var(--color-dark); color: #fff; border-color: var(--color-dark); }
 .at-btn-secondary:hover { background: #2a3a52; border-color: #2a3a52; }
 
+/* Sync rows — compact single-line entries (Sync tab) */
+.at-dot-sm { width: 9px; height: 9px; }
+.at-sync-entry { padding: 4px 0; }
+.at-sync-line {
+  display: flex; align-items: center; gap: 9px;
+  background: #faf8fe; border: 1px solid #ece4f9;
+  border-radius: 8px; padding: 7px 12px; min-width: 0;
+  transition: border-color .12s;
+}
+.at-sync-entry:hover .at-sync-line { border-color: #ddccf5; }
+.at-sync-line-unsynced { background: #fdf9f0; border-color: #f4ead2; }
+.at-sync-entry:hover .at-sync-line-unsynced { border-color: #ecd9af; }
+.at-sync-text {
+  font-size: 12.5px; color: #2c3849;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.at-sync-text b { color: #0f1623; font-weight: 600; }
+.at-sync-spacer { flex: 1 1 auto; min-width: 8px; }
+.at-sync-actor { color: var(--color-dark); font-weight: 600; font-size: 12px; white-space: nowrap; }
+.at-sync-ts { font-variant-numeric: tabular-nums; color: #7d8ba0; font-size: 11px; white-space: nowrap; }
+
+/* Collapsed run of consecutive auto-syncs */
+.at-run-entry { padding: 4px 0; }
+.at-run-wrap {
+  border: 1px solid #ece4f9; border-radius: 8px;
+  background: #faf8fe; overflow: hidden; min-width: 0; width: 100%;
+}
+.at-run-summary {
+  display: flex; align-items: center; gap: 9px;
+  width: 100%; text-align: left; font: inherit; font-family: inherit;
+  background: transparent; border: 0; cursor: pointer; padding: 8px 12px;
+}
+.at-run-summary:hover { background: #f4eefc; }
+.at-run-count { font-size: 12.5px; font-weight: 600; color: #0f1623; white-space: nowrap; }
+.at-run-range { font-size: 11px; color: #7d8ba0; font-variant-numeric: tabular-nums; white-space: nowrap; }
+.at-run-toggle {
+  display: inline-flex; align-items: center; gap: 4px;
+  font-size: 11.5px; font-weight: 600; color: #6d28d9; white-space: nowrap;
+}
+.at-run-chevron { transition: transform .15s; }
+.at-run-summary.is-open .at-run-chevron { transform: rotate(180deg); }
+.at-run-list {
+  list-style: none; margin: 0; padding: 2px 12px 8px 14px;
+  border-top: 1px solid #ece4f9;
+}
+.at-run-item { display: flex; align-items: center; gap: 9px; padding: 5px 0; }
+.at-run-bullet { width: 5px; height: 5px; border-radius: 50%; flex-shrink: 0; }
+.at-run-item-text {
+  font-size: 12px; color: #2c3849;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.at-run-item-text b { color: #0f1623; font-weight: 600; }
+.at-run-item-actor { color: #5a6a7e; font-weight: 600; font-size: 11.5px; white-space: nowrap; }
+.at-run-item-ts { color: #7d8ba0; font-size: 11px; font-variant-numeric: tabular-nums; white-space: nowrap; }
+
 /* =================== Inline Editing Modals (iem-) =================== */
 :root {
   --iem-sky:      #2db4e8;

--- a/js/audit_trail.js
+++ b/js/audit_trail.js
@@ -15,7 +15,12 @@
     'invoice_updated':  { label: 'Invoice Updated',  color: '#ea580c', bg: '#fdebd9', fg: '#c2410c', group: 'invoices' },
     'invoice_deleted':  { label: 'Invoice Deleted',  color: '#ea580c', bg: '#fdebd9', fg: '#c2410c', group: 'invoices' },
     'document_updated': { label: 'Document Updated', color: '#2563eb', bg: '#e8f0fc', fg: '#1d4ed8', group: 'edits'    },
-    'net_30':           { label: 'Field Edited',     color: '#2563eb', bg: '#e8f0fc', fg: '#1d4ed8', group: 'edits'    }
+    'net_30':           { label: 'Field Edited',     color: '#2563eb', bg: '#e8f0fc', fg: '#1d4ed8', group: 'edits'    },
+    // Quote lifecycle events. 'quote_created' is a Status-group marker; sync events live
+    // in their own 'sync' group and render as compact single-line rows (see at-sync-*).
+    'quote_created':    { label: 'Quote Created',   color: '#16a34a', bg: '#e8f6ec', fg: '#15803d', group: 'status' },
+    'sync_to_sheet':    { label: 'Synced',          color: '#7c3aed', bg: '#f1ebfc', fg: '#6d28d9', group: 'sync', syncType: 'synced'   },
+    'break_sync':       { label: 'Unsynced',        color: '#d97706', bg: '#fdf1de', fg: '#b45309', group: 'sync', syncType: 'unsynced' }
   };
   var AT_DEFAULT = { label: 'Modified', color: '#2563eb', bg: '#e8f0fc', fg: '#1d4ed8', group: 'edits' };
 
@@ -65,6 +70,12 @@
     };
   }
 
+  // Short clock time (e.g. "3:42 PM") for the compact sync rows + collapsed runs.
+  function atTimeShort(dateStr) {
+    var d = new Date(dateStr.replace(' ', 'T'));
+    return d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+  }
+
   function atEsc(s) {
     return String(s)
       .replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;')
@@ -89,7 +100,7 @@
       return atScopeTab === 'full' || e.scope === atScopeTab;
     });
     var g = function (grp) { return base.filter(function (e) { return atType(e.action_type).group === grp; }).length; };
-    return { all: base.length, status: g('status'), edits: g('edits'), items: g('items'), invoices: g('invoices') };
+    return { all: base.length, status: g('status'), edits: g('edits'), items: g('items'), invoices: g('invoices'), sync: g('sync') };
   }
 
   // ---------- Render one entry ----------
@@ -131,6 +142,89 @@
     '</li>';
   }
 
+  // ---------- Sync rows (compact single-line) ----------
+  // A consecutive run of 3+ 'synced' events collapses into one expandable summary so a
+  // high-volume auto-sync history doesn't drown the timeline. 'unsynced' is always its own row.
+  function atBuildUnits(items) {
+    var units = [];
+    var i = 0;
+    while (i < items.length) {
+      var st = atType(items[i].action_type).syncType;
+      if (st === 'synced') {
+        var j = i;
+        while (j < items.length && atType(items[j].action_type).syncType === 'synced') { j++; }
+        var run = items.slice(i, j);
+        if (run.length >= 3) {
+          units.push({ kind: 'run', items: run });
+        } else {
+          run.forEach(function (r) { units.push({ kind: 'sync', e: r }); });
+        }
+        i = j;
+      } else if (st === 'unsynced') {
+        units.push({ kind: 'sync', e: items[i] }); i++;
+      } else {
+        units.push({ kind: 'entry', e: items[i] }); i++;
+      }
+    }
+    return units;
+  }
+
+  function atRenderSyncEntry(e, showLine) {
+    var t = atType(e.action_type);
+    var shadow = '0 0 0 3px #fff,0 0 0 4px ' + t.color + '33';
+    var lineClass = t.syncType === 'unsynced' ? ' at-sync-line-unsynced' : '';
+    return '<li class="at-entry at-sync-entry">' +
+      '<div class="at-rail">' +
+        '<span class="at-dot at-dot-sm" style="background:' + t.color + ';box-shadow:' + shadow + '"></span>' +
+        (showLine ? '<span class="at-line"></span>' : '') +
+      '</div>' +
+      '<div class="at-sync-line' + lineClass + '">' +
+        '<span class="at-badge" style="background:' + t.bg + ';color:' + t.fg + '">' +
+          '<span class="at-badge-dot" style="background:' + t.color + '"></span>' + t.label +
+        '</span>' +
+        '<span class="at-sync-text">' + e.audit_trail + '</span>' +
+        '<span class="at-sync-spacer"></span>' +
+        '<span class="at-sync-actor">' + atEsc(e.username) + '</span>' +
+        '<span class="at-sync-ts">' + atEsc(atTimeShort(e.created_date)) + '</span>' +
+      '</div>' +
+    '</li>';
+  }
+
+  function atRenderSyncRun(items, showLine) {
+    var t = atType('sync_to_sheet');
+    var shadow = '0 0 0 3px #fff,0 0 0 4px ' + t.color + '33';
+    var newest = items[0], oldest = items[items.length - 1];
+    var listItems = items.map(function (e) {
+      return '<li class="at-run-item">' +
+        '<span class="at-run-bullet" style="background:' + t.color + '"></span>' +
+        '<span class="at-run-item-text">' + e.audit_trail + '</span>' +
+        '<span class="at-sync-spacer"></span>' +
+        '<span class="at-run-item-actor">' + atEsc(e.username) + '</span>' +
+        '<span class="at-run-item-ts">' + atEsc(atTimeShort(e.created_date)) + '</span>' +
+      '</li>';
+    }).join('');
+    return '<li class="at-entry at-run-entry">' +
+      '<div class="at-rail">' +
+        '<span class="at-dot at-dot-sm" style="background:' + t.color + ';box-shadow:' + shadow + '"></span>' +
+        (showLine ? '<span class="at-line"></span>' : '') +
+      '</div>' +
+      '<div class="at-run-wrap">' +
+        '<button type="button" class="at-run-summary">' +
+          '<span class="at-badge" style="background:' + t.bg + ';color:' + t.fg + '">' +
+            '<span class="at-badge-dot" style="background:' + t.color + '"></span>' + t.label +
+          '</span>' +
+          '<span class="at-run-count">' + items.length + ' automatic syncs</span>' +
+          '<span class="at-run-range">' + atEsc(atTimeShort(oldest.created_date)) + ' &ndash; ' + atEsc(atTimeShort(newest.created_date)) + '</span>' +
+          '<span class="at-sync-spacer"></span>' +
+          '<span class="at-run-toggle"><span class="at-run-toggle-text">Show all</span>' +
+            '<svg class="at-run-chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>' +
+          '</span>' +
+        '</button>' +
+        '<ul class="at-run-list" style="display:none">' + listItems + '</ul>' +
+      '</div>' +
+    '</li>';
+  }
+
   // ---------- Render grouped timeline ----------
   function atRenderGrouped(filtered) {
     var groups = [];
@@ -147,9 +241,12 @@
         '<div class="at-day-label"><span>' + atEsc(g.day) + '</span>' +
         '<span class="at-day-count">' + g.items.length + (g.items.length === 1 ? ' event' : ' events') + '</span></div>' +
         '<ul class="at-timeline">';
-      g.items.forEach(function (e, i) {
-        var last = i === g.items.length - 1 && gi === groups.length - 1;
-        html += atRenderEntry(e, !last);
+      var units = atBuildUnits(g.items);
+      units.forEach(function (u, i) {
+        var showLine = i < units.length - 1 || gi < groups.length - 1;
+        if (u.kind === 'run')       html += atRenderSyncRun(u.items, showLine);
+        else if (u.kind === 'sync') html += atRenderSyncEntry(u.e, showLine);
+        else                        html += atRenderEntry(u.e, showLine);
       });
       html += '</ul></div>';
     });
@@ -252,6 +349,15 @@
     $modal.on('input', '.at-search-input', function () {
       atSearch = $(this).val();
       atUpdateUI();
+    });
+
+    // Expand / collapse a run of auto-syncs
+    $modal.on('click', '.at-run-summary', function () {
+      var $list = $(this).closest('.at-run-wrap').find('.at-run-list');
+      var open  = $list.is(':visible');
+      $list.toggle(!open);
+      $(this).toggleClass('is-open', !open);
+      $(this).find('.at-run-toggle-text').text(open ? 'Show all' : 'Hide');
     });
 
     // Scroll-to-item link (closes modal, highlights row)

--- a/plantillas/fulfillment/modals/audit_trails_modal.inc.php
+++ b/plantillas/fulfillment/modals/audit_trails_modal.inc.php
@@ -26,6 +26,7 @@
           <button class="at-tab" data-tab="edits">Edits <span class="at-tab-count">0</span></button>
           <button class="at-tab" data-tab="items">Items <span class="at-tab-count">0</span></button>
           <button class="at-tab" data-tab="invoices">Invoices <span class="at-tab-count">0</span></button>
+          <button class="at-tab" data-tab="sync">Sync <span class="at-tab-count">0</span></button>
           <div class="at-search">
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
             <input class="at-search-input" type="text" placeholder="Search audit trail" />

--- a/plantillas/quote/modals/audit_trails_modal.inc.php
+++ b/plantillas/quote/modals/audit_trails_modal.inc.php
@@ -26,6 +26,7 @@
           <button class="at-tab" data-tab="edits">Edits <span class="at-tab-count">0</span></button>
           <button class="at-tab" data-tab="items">Items <span class="at-tab-count">0</span></button>
           <button class="at-tab" data-tab="invoices">Invoices <span class="at-tab-count">0</span></button>
+          <button class="at-tab" data-tab="sync">Sync <span class="at-tab-count">0</span></button>
           <div class="at-search">
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
             <input class="at-search-input" type="text" placeholder="Search audit trail" />

--- a/plantillas/quote/validacion_registro_cotizacion.inc.php
+++ b/plantillas/quote/validacion_registro_cotizacion.inc.php
@@ -109,6 +109,8 @@ function createAndInsertQuote($validador, $usuario_designado) {
 
   // Log audit trails
   logAuditTrails($id_rfq, $validador);
+  // Single lifecycle marker alongside the per-field creation entries (Status tab).
+  AuditTrailRepository::quote_created_audit_trail(Conexion::obtener_conexion(), $id_rfq);
 
   // Auto-sync to the SharePoint sheet when the user opted in via the "Sync to pipeline"
   // checkbox. The checkbox is the sole gate — bid type only sets its default in the form,
@@ -119,6 +121,7 @@ function createAndInsertQuote($validador, $usuario_designado) {
       $insertedQuote = RepositorioRfq::obtener_cotizacion_por_id(Conexion::obtener_conexion(), $id_rfq);
       $sheetRow = SheetSyncService::appendRow($insertedQuote, $designatedUsername);
       SheetSyncRepository::updateSyncStatus(Conexion::obtener_conexion(), $id_rfq, 'synced', $sheetRow);
+      AuditTrailRepository::sync_to_sheet_audit_trail(Conexion::obtener_conexion(), $id_rfq);
     } catch (Exception $syncEx) {
       SheetSyncRepository::updateSyncStatus(Conexion::obtener_conexion(), $id_rfq, 'failed');
       error_log('Sheet sync error on create: ' . $syncEx->getMessage());

--- a/plantillas/re_quote/modals/audit_trails_modal.inc.php
+++ b/plantillas/re_quote/modals/audit_trails_modal.inc.php
@@ -26,6 +26,7 @@
           <button class="at-tab" data-tab="edits">Edits <span class="at-tab-count">0</span></button>
           <button class="at-tab" data-tab="items">Items <span class="at-tab-count">0</span></button>
           <button class="at-tab" data-tab="invoices">Invoices <span class="at-tab-count">0</span></button>
+          <button class="at-tab" data-tab="sync">Sync <span class="at-tab-count">0</span></button>
           <div class="at-search">
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
             <input class="at-search-input" type="text" placeholder="Search audit trail" />

--- a/scripts/quote/break_sheet_sync.php
+++ b/scripts/quote/break_sheet_sync.php
@@ -27,6 +27,7 @@ try {
   // and flip the status to 'never' for the UI badge.
   SheetSyncRepository::setSyncToSheet($conexion, $id_rfq, 0);
   SheetSyncRepository::updateSyncStatus($conexion, $id_rfq, 'never');
+  AuditTrailRepository::break_sync_audit_trail($conexion, $id_rfq);
 
   Conexion::cerrar_conexion();
 

--- a/scripts/quote/save_information.php
+++ b/scripts/quote/save_information.php
@@ -63,6 +63,7 @@ if (isset($_POST['save_information'])) {
           $writtenRow = SheetSyncService::appendRow($updatedQuote, $designatedUsername);
         }
         SheetSyncRepository::updateSyncStatus($conexion, $_POST['id_rfq'], 'synced', $writtenRow);
+        AuditTrailRepository::sync_to_sheet_audit_trail($conexion, $_POST['id_rfq']);
       }
     } catch (Exception $syncEx) {
       SheetSyncRepository::updateSyncStatus($conexion, $_POST['id_rfq'], 'failed');

--- a/scripts/quote/sync_to_sheet.php
+++ b/scripts/quote/sync_to_sheet.php
@@ -44,6 +44,7 @@ try {
   SheetSyncRepository::updateSyncStatus(Conexion::obtener_conexion(), $id_rfq, 'synced', $sheetRow);
   // Manually syncing also turns the per-quote flag on, so future edits auto-sync.
   SheetSyncRepository::setSyncToSheet(Conexion::obtener_conexion(), $id_rfq, 1);
+  AuditTrailRepository::sync_to_sheet_audit_trail(Conexion::obtener_conexion(), $id_rfq);
   $syncAt = date('M j, Y \a\t g:i A');
   Conexion::cerrar_conexion();
 

--- a/tests/php/quote_lifecycle_audit_test.php
+++ b/tests/php/quote_lifecycle_audit_test.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Integration test for the Quote Lifecycle audit helpers on AuditTrailRepository:
+ *   - quote_created_audit_trail  -> action_type 'quote_created' (Status group, green)
+ *   - sync_to_sheet_audit_trail  -> action_type 'sync_to_sheet' (Sync group, "Synced")
+ *   - break_sync_audit_trail     -> action_type 'break_sync'    (Sync group, "Unsynced")
+ *
+ * Each helper mirrors quote_status_audit_trail: it derives username/id from
+ * $_SESSION['user] and writes one row through insert_audit_trail. The test stubs
+ * the session user, inserts a quote, calls each helper, reads back the rows, then
+ * ROLLS BACK so nothing persists.
+ *
+ * Run:  docker exec lamp-php83 php /var/www/html/rfq/tests/php/quote_lifecycle_audit_test.php
+ */
+
+$root = __DIR__ . '/../../';
+require_once $root . 'app/Bootstrap/config.inc.php';
+require_once $root . 'app/Bootstrap/Conexion.inc.php';
+require_once $root . 'app/Quote/AuditTrail.inc.php';
+require_once $root . 'app/Comment/RepositorioComment.inc.php';
+require_once $root . 'app/Quote/AuditTrailRepository.inc.php';
+
+$pass = 0; $fail = 0;
+function check($label, $expected, $actual) {
+  global $pass, $fail;
+  $ok = $expected === $actual;
+  if ($ok) { $pass++; echo "  PASS  $label\n"; }
+  else     { $fail++; echo "  FAIL  $label — expected " . var_export($expected, true) . ", got " . var_export($actual, true) . "\n"; }
+}
+
+/** Minimal stand-in for the logged-in user the helpers read from the session. */
+class FakeSessionUser {
+  private $id; private $name;
+  public function __construct($id, $name) { $this->id = $id; $this->name = $name; }
+  public function obtener_id() { return $this->id; }
+  public function obtener_nombre_usuario() { return $this->name; }
+}
+$_SESSION['user'] = new FakeSessionUser(7, 'RSantos');
+
+$conexion = Conexion::obtener_conexion();
+
+function insertQuote($conexion, array $o = []) {
+  $f = array_merge([
+    'id_usuario' => 1, 'usuario_designado' => 1, 'canal' => 'AUDITTEST',
+    'email_code' => 'AUDIT-' . uniqid(), 'type_of_bid' => 'IT',
+    'issue_date' => '01/01/1999', 'end_date' => '01/01/1999', 'status' => 0, 'completado' => 0,
+    'comments' => 'No comments', 'award' => 0, 'payment_terms' => 'Net 30',
+    'address' => '', 'ship_to' => '', 'ship_via' => '', 'taxes' => 0, 'profit' => 0,
+    'additional' => '', 'shipping_cost' => 0, 'shipping' => '', 'fullfillment' => 0,
+    'contract_number' => '', 'total_price' => 0,
+    'invoice' => 0, 'submitted_invoice' => 0, 'deleted' => 0, 'name' => 'Audit Test',
+  ], $o);
+  $cols = array_keys($f);
+  $ph = array_map(fn($c) => ':' . $c, $cols);
+  $sql = 'INSERT INTO rfq (' . implode(',', $cols) . ') VALUES (' . implode(',', $ph) . ')';
+  $stmt = $conexion->prepare($sql);
+  foreach ($f as $c => $v) { $stmt->bindValue(':' . $c, $v); }
+  $stmt->execute();
+  return (int)$conexion->lastInsertId();
+}
+
+/** Read back the audit rows for a quote, newest first. */
+function readAudit($conexion, $id_rfq) {
+  $stmt = $conexion->prepare('SELECT username, action_type, id_user, audit_trail FROM audit_trails WHERE id_rfq = :id ORDER BY id DESC');
+  $stmt->bindValue(':id', $id_rfq, PDO::PARAM_INT);
+  $stmt->execute();
+  return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+$conexion->beginTransaction();
+try {
+  $id_rfq = insertQuote($conexion);
+
+  echo "[quote_created]\n";
+  AuditTrailRepository::quote_created_audit_trail($conexion, $id_rfq);
+  $rows = readAudit($conexion, $id_rfq);
+  check('one row written', 1, count($rows));
+  check('action_type = quote_created', 'quote_created', $rows[0]['action_type']);
+  check('username from session', 'RSantos', $rows[0]['username']);
+  check('id_user from session', '7', (string)$rows[0]['id_user']);
+  check('message mentions Created', true, strpos($rows[0]['audit_trail'], 'Created') !== false);
+
+  echo "[sync_to_sheet]\n";
+  AuditTrailRepository::sync_to_sheet_audit_trail($conexion, $id_rfq);
+  $rows = readAudit($conexion, $id_rfq);
+  check('two rows total', 2, count($rows));
+  check('newest action_type = sync_to_sheet', 'sync_to_sheet', $rows[0]['action_type']);
+  check('synced message mentions synced', true, stripos($rows[0]['audit_trail'], 'synced') !== false);
+
+  echo "[break_sync]\n";
+  AuditTrailRepository::break_sync_audit_trail($conexion, $id_rfq);
+  $rows = readAudit($conexion, $id_rfq);
+  check('three rows total', 3, count($rows));
+  check('newest action_type = break_sync', 'break_sync', $rows[0]['action_type']);
+  check('unsync message mentions unsynced', true, stripos($rows[0]['audit_trail'], 'unsynced') !== false);
+
+  echo "[repeated syncs each write a row]\n";
+  AuditTrailRepository::sync_to_sheet_audit_trail($conexion, $id_rfq);
+  AuditTrailRepository::sync_to_sheet_audit_trail($conexion, $id_rfq);
+  $rows = readAudit($conexion, $id_rfq);
+  $syncCount = count(array_filter($rows, fn($r) => $r['action_type'] === 'sync_to_sheet'));
+  check('three sync_to_sheet rows after 3 syncs', 3, $syncCount);
+
+} finally {
+  $conexion->rollBack();
+}
+
+echo "\n==== $pass passed, $fail failed ====\n";
+exit($fail === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Logs audit-trail events on quote **create**, sheet **sync**, and **break-sync**, surfaced through the unified Audit Trail modal's new **Sync** tab. Implements the planned `quote-lifecycle-audit-events` feature with the visual design from the *Audit Trail.html* Claude Design handoff.

## Backend

Three helpers on `AuditTrailRepository` mirroring `quote_status_audit_trail` (session-derived username/id, one `insert_audit_trail` row):

- `quote_created_audit_trail` → `quote_created` (Status group)
- `sync_to_sheet_audit_trail` → `sync_to_sheet` ("Synced")
- `break_sync_audit_trail` → `break_sync` ("Unsynced")

Call sites: quote creation (after `logAuditTrails`), all three sync paths (manual **Sync to Sheet** button, on-create auto-sync, on-save auto-sync) after a successful `synced` status, and **Break Sync**. Only **successful** syncs are logged; a failed sync (`status → failed`) records nothing.

No schema change — reuses the existing `action_type VARCHAR(50)` column; the unified endpoint returns the new rows with no query change.

## Frontend (design)

- New **Sync** filter tab on all three modal shells (quote / fulfillment / re-quote).
- `js/audit_trail.js`: new sync action types + sync-group counts; sync events render as compact single-line rows (purple **Synced** / amber **Unsynced**) instead of full cards; 3+ consecutive auto-syncs collapse into an expandable "N automatic syncs" run.
- `at-sync-*` / `at-run-*` CSS ported from the design bundle.

## Tests

`tests/php/quote_lifecycle_audit_test.php` — 12 assertions, transaction-isolated (TDD red → green). Existing PHP tests still pass; all touched PHP/JS lint clean.

Run: `docker exec lamp-php83 php /var/www/html/rfq/tests/php/quote_lifecycle_audit_test.php`

## Out of scope (per spec)

Failed-sync logging, per-save de-duplication, fulfillment/re-quote sync events, the `copyRfq` path, and history backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)