### PR TITLE
feat: write-once sheet sync with Created/Linked audit events

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 | Bid Pipeline Metrics Dashboard (interactive ApexCharts report reproducing the SharePoint METRICS 2026 tab from app data) | built | — |
 | 3-Year Annual Awards Comparison (Charts tab annual cards: rolling current + 2 prior years) | built | — |
 | Quote Lifecycle Audit Events (audit-trail entries on quote create / sync / unsync, surfaced via the Audit Trail modal's Sync tab) | built | — |
+| Write-Once Sheet Sync (app creates a sheet row if missing but never overwrites/deletes an existing one — sync becomes create-or-link) | built | — |
 
 ## Environment
 
@@ -84,14 +85,13 @@ All URL constants are defined in [app/Bootstrap/routes.inc.php](app/Bootstrap/ro
 
 A quote (`Rfq`) progresses through: Created → Completed → Submitted → Award → Fulfillment → Invoice. The `comments` field encodes special statuses (No Bid, Cancelled, Not submitted). The `isEnabledToFulfillment()` and `isEnabledToInvoice()` methods on the `Rfq` class enforce prerequisites for state transitions.
 
-### SharePoint Sheet Sync — row-pointer invariants
+### SharePoint Sheet Sync — write-once create-or-link
 
-The DB column `rfq.sheet_row` is the source of truth for which sheet row a quote owns; the sheet itself (Graph `usedRange`) is only **eventually consistent**, so never decide append-vs-update by scanning it when a pointer exists.
-- `syncRow($sheetRow,…)` is **self-healing**: it reads the full `A:T` of `$sheetRow`, verifies column A equals the quote id before writing; if it drifted it re-resolves via `appendRow` (column-A scan) and returns the corrected row — callers must persist the returned value.
-- `appendRow` reads row-count + column A to find/append; before overwriting an existing row it reads that row's `A:T` so human columns survive.
-- After `deleteRow` (shift='Up'), call `SheetSyncRepository::shiftRowsAfterDelete()` to decrement pointers below the deleted row.
-- **Per-quote `sync_to_sheet` flag is the sole auto-sync gate** (not bid type, not child/master-link). Creation form's "Sync to pipeline" checkbox sets it (JS smart-defaults it from bid type via the syncable list — all A/V variants + `IT`/`MOVING & LOGISTICS`/`PROFESSIONAL SERVICES`/`Services` — but the user can override). `Sync to Sheet` btn sets flag=1 (+status `synced`); `Break Sync` sets flag=0 (keeps `sheet_row`, status `never`). `copyRfq` sets copies to 0.
-- **Read-merge-write column ownership** (`SheetSyncService::mergeAppOwned`): app rewrites A,B,C,D,G,H,J,L,M,N,Q,T each sync; **E (STATUS), F (INTERNAL DUE DATE), I, K, O, P, R, S are human-owned** and preserved (blank on brand-new rows). Status transitions in `guardar_editar_cotizacion.php` no longer push STATUS (that helper is now a no-op).
+The app is **strictly non-destructive** to the sheet: it may create a missing pipeline row but never overwrites or deletes an existing one. Every sync path routes through `SheetSyncService::createOrLink($quote, $designatedUsername)` → `['row','outcome']`:
+- Presence is decided by **scanning column A** (PROPOSAL = quote id), never by trusting the stored `sheet_row`. **Found** → that row becomes the pointer, write nothing, `outcome='linked'`. **Absent** → append a fresh row (`buildRowValues`: app columns filled, human columns blank), `outcome='created'`. No Graph secret → `outcome=null`.
+- Persist only on **establishment** (created, or linked to a row not already pointed at, or prior status ≠ `synced`): `updateSyncStatus('synced', row)` + matching audit event. A no-op edit of an already-linked quote makes **zero** Graph writes, no `sheet_sync_at` bump, no audit row. Old overwrite paths (`syncRow`, `appendRow`) + `deleteRow`/`shiftRowsAfterDelete` are retired/unused; quote delete never touches the sheet.
+- **Per-quote `sync_to_sheet` flag is the sole auto-sync gate** (not bid type, not child/master-link). Creation "Sync to pipeline" checkbox sets it (JS smart-defaults from bid type via the syncable list — all A/V variants + `IT`/`MOVING & LOGISTICS`/`PROFESSIONAL SERVICES`/`Services` — user can override). `Sync to Sheet` btn create-or-links + flag=1 (returns `outcome` for the button label); `Break Sync` → flag=0 (keeps `sheet_row`, status `never`); `copyRfq` → 0.
+- **Column ownership:** app owns A,B,C,D,G,H,J,L,M,N,Q,T; **E,F,I,K,O,P,R,S are human-owned**, written blank only on a brand-new created row — existing rows never touched.
 
 ### Unified Audit Trail
 
@@ -104,11 +104,11 @@ All three domains write to their own audit table but are surfaced through a sing
 - `app/ReQuote/ReQuoteAuditTrailRepository.inc.php` — same pattern for re-quote
 - `app/Fulfillment/FulfillmentAuditTrailRepository.inc.php` — adds `status_event()`, `invoice_event()`, `net_30_event()` helpers
 
-**Action types** (stored in `action_type` column): `status_change`, `field_modified`, `item_modified`, `item_created`, `item_deleted`, `invoice_created`, `invoice_updated`, `invoice_deleted`, `document_updated`, `net_30`, `quote_created` (Status group), `sync_to_sheet`/`break_sync` (Sync group — quote only). The three lifecycle helpers on `AuditTrailRepository` (`quote_created_audit_trail`, `sync_to_sheet_audit_trail`, `break_sync_audit_trail`) mirror `quote_status_audit_trail`; only **successful** syncs are logged (every flagged save logs one — accepted noise, isolated under the Sync tab). Call sites: create (`validacion_registro_cotizacion.inc.php`), all 3 sync paths after a `synced` status (`sync_to_sheet.php`, on-create + on-save auto-sync), and `break_sheet_sync.php`.
+**Action types** (stored in `action_type` column): `status_change`, `field_modified`, `item_modified`, `item_created`, `item_deleted`, `invoice_created`, `invoice_updated`, `invoice_deleted`, `document_updated`, `net_30`, `quote_created` (Status group), and the Sync group (quote only): `sheet_row_created`/`sheet_row_linked` (write-once outcomes), `break_sync`, plus legacy `sync_to_sheet` (historical "Synced" rows, still rendered). `AuditTrailRepository` helpers (`sheet_row_created_audit_trail`/`sheet_row_linked_audit_trail`/`break_sync_audit_trail`/`quote_created_audit_trail`) mirror `quote_status_audit_trail`. **Logged once on establishment** — a no-op sync logs nothing. Call sites: create, on-save auto-sync (`save_information.php`), manual `sync_to_sheet.php`, `break_sheet_sync.php`.
 
 **Unified endpoint:** `POST /rfq/quote/load_unified_audit_trail` (`scripts/quote/load_unified_audit_trail.php`) — accepts `id_rfq`, queries all three tables (re-quote joined via `re_quotes.id_rfq`), merges and sorts by `created_date DESC`, returns JSON array. Each entry has: `id, username, action_type, audit_trail, created_date, scope` (scope values: `quote`, `requote`, `fulfillment`).
 
-**Frontend:** `js/audit_trail.js` — self-contained IIFE; handles open/load/filter/render for all three pages. Included in `editar_cotizacion.inc.php`, `fulfillment.inc.php`, and `re_quote.inc.php`. The trigger buttons (`#audit_trails_button`, `#fulfillment_audit_trails_button`) must have `data-id="<id_rfq>"`. Primary filter tabs: All / Status / Edits / Items / Invoices / **Sync**. Sync-group events render as compact single-line rows (`at-sync-*`, purple Synced / amber Unsynced) instead of full cards; 3+ consecutive `sync_to_sheet` events collapse into one expandable "N automatic syncs" run (`at-run-*`, `atBuildUnits`).
+**Frontend:** `js/audit_trail.js` — self-contained IIFE; handles open/load/filter/render for all three pages. Included in `editar_cotizacion.inc.php`, `fulfillment.inc.php`, and `re_quote.inc.php`. The trigger buttons (`#audit_trails_button`, `#fulfillment_audit_trails_button`) must have `data-id="<id_rfq>"`. Primary filter tabs: All / Status / Edits / Items / Invoices / **Sync**. Sync-group events render as compact single-line rows (`at-sync-*`) with a colored icon chip + distinct glyph per outcome — **Created** (violet, sheet-plus), **Linked** (cyan, link), **Unsynced** (amber, unlink); legacy `sync_to_sheet` falls back to a violet "Synced" row. 3+ consecutive synced (create/link) events collapse into one type-neutral "N automatic syncs" run with a `2 created · 1 linked` breakdown (`at-run-*`, `atBuildUnits`, `atSyncGlyph`); expanded run items keep their per-outcome accent.
 
 **Modal templates** (all identical unified shell, `id="audit_trails_modal"`):
 - `plantillas/quote/modals/audit_trails_modal.inc.php`

--- a/app/Quote/AuditTrailRepository.inc.php
+++ b/app/Quote/AuditTrailRepository.inc.php
@@ -362,9 +362,25 @@ class AuditTrailRepository {
     self::insert_audit_trail($connection, $audit_trail);
   }
 
+  // Legacy generic "Synced" event. Superseded by the write-once create/link helpers below,
+  // but kept so historical sync_to_sheet rows still render. New sync paths log create/link.
   public static function sync_to_sheet_audit_trail($connection, $id_rfq) {
     $message = 'Quote synced to <b>Bid Pipeline</b>';
     $audit_trail = new AuditTrail('', $id_rfq, $_SESSION['user']->obtener_nombre_usuario(), 'sync_to_sheet', $_SESSION['user']->obtener_id(), $message, '');
+    self::insert_audit_trail($connection, $audit_trail);
+  }
+
+  // Write-once sheet sync: the app added a brand-new pipeline row for this quote.
+  public static function sheet_row_created_audit_trail($connection, $id_rfq) {
+    $message = 'Created row in <b>Bid Pipeline</b>';
+    $audit_trail = new AuditTrail('', $id_rfq, $_SESSION['user']->obtener_nombre_usuario(), 'sheet_row_created', $_SESSION['user']->obtener_id(), $message, '');
+    self::insert_audit_trail($connection, $audit_trail);
+  }
+
+  // Write-once sheet sync: the app attached to a row that already existed, writing nothing.
+  public static function sheet_row_linked_audit_trail($connection, $id_rfq) {
+    $message = 'Linked to existing <b>Bid Pipeline</b> row';
+    $audit_trail = new AuditTrail('', $id_rfq, $_SESSION['user']->obtener_nombre_usuario(), 'sheet_row_linked', $_SESSION['user']->obtener_id(), $message, '');
     self::insert_audit_trail($connection, $audit_trail);
   }
 

--- a/app/Quote/SheetSyncService.inc.php
+++ b/app/Quote/SheetSyncService.inc.php
@@ -88,6 +88,42 @@ class SheetSyncService {
     return 'A' . $rowIndex . ':T' . $rowIndex;
   }
 
+  // Write-once create-or-link. Presence is decided by scanning column A (the stored
+  // sheet_row pointer is never trusted as a license to write). If the quote id is already
+  // in the sheet, that row becomes the pointer and NOTHING is written (link). If it's
+  // absent, a fresh row is appended with the app-owned columns filled and human-owned
+  // columns left blank (create). The app never overwrites or deletes an existing row.
+  //
+  // Returns ['row' => int|null, 'outcome' => 'created'|'linked'|null]. When Graph is not
+  // configured, returns a null outcome so callers treat it as "sync not performed".
+  public static function createOrLink(Rfq $quote, $designatedUsername) {
+    if (empty(GRAPH_CLIENT_SECRET)) {
+      return ['row' => null, 'outcome' => null];
+    }
+
+    $range       = self::getUsedRange();
+    $existingRow = self::findRowByQuoteId($quote->obtener_id(), $range['values']);
+
+    // Found in the sheet — link only, write nothing (human-owned and app-owned cells stay
+    // exactly as they are).
+    if ($existingRow) {
+      return ['row' => $existingRow, 'outcome' => 'linked'];
+    }
+
+    // Absent — create. A genuinely new row has no existing values, so human-owned cells
+    // stay blank (buildRowValues already emits them empty); no read-merge needed.
+    $targetRow = $range['rowCount'] + 1;
+    $values    = self::buildRowValues($quote, $designatedUsername);
+    GraphApiClient::patch(self::wsPath('/range(address=\'' . self::rowAddress($targetRow) . '\')'), [
+      'values' => [$values],
+    ]);
+
+    return ['row' => $targetRow, 'outcome' => 'created'];
+  }
+
+  // --- Superseded by createOrLink() under the write-once model (kept for reference /
+  //     historical callers). appendRow/syncRow could overwrite an existing row; the app no
+  //     longer does that. deleteRow has no callers — the app never removes a sheet row. ---
   public static function appendRow(Rfq $quote, $designatedUsername) {
     if (empty(GRAPH_CLIENT_SECRET)) {
       return null;

--- a/css/estilos.css
+++ b/css/estilos.css
@@ -1962,60 +1962,90 @@ h3.text-info.text-center .fa-exclamation-circle {
 .at-btn-secondary { background: var(--color-dark); color: #fff; border-color: var(--color-dark); }
 .at-btn-secondary:hover { background: #2a3a52; border-color: #2a3a52; }
 
-/* Sync rows — compact single-line entries (Sync tab) */
+/* Sync rows — compact single-line entries (Sync tab).
+   Write-once: per-outcome tints + colored icon chips — Created = violet, Linked = cyan,
+   Unsynced = amber. Legacy generic "Synced" reuses the violet tint. */
 .at-dot-sm { width: 9px; height: 9px; }
+.at-dot-run { background: #94a3b8; }
 .at-sync-entry { padding: 4px 0; }
 .at-sync-line {
-  display: flex; align-items: center; gap: 9px;
-  background: #faf8fe; border: 1px solid #ece4f9;
-  border-radius: 8px; padding: 7px 12px; min-width: 0;
-  transition: border-color .12s;
+  display: flex; align-items: center; gap: 10px;
+  background: #fff; border: 1px solid #e3e7ee;
+  border-radius: 8px; padding: 6px 11px 6px 8px; min-width: 0;
+  transition: border-color .12s, background .12s;
 }
-.at-sync-entry:hover .at-sync-line { border-color: #ddccf5; }
+.at-sync-line-rowCreated { background: #f8f4fe; border-color: #e7dcfb; }
+.at-sync-entry:hover .at-sync-line-rowCreated { border-color: #d6c4f5; }
+.at-sync-line-rowLinked { background: #eff8fc; border-color: #d4ebf6; }
+.at-sync-entry:hover .at-sync-line-rowLinked { border-color: #bfe1ef; }
+.at-sync-line-synced { background: #faf8fe; border-color: #ece4f9; }
+.at-sync-entry:hover .at-sync-line-synced { border-color: #ddccf5; }
 .at-sync-line-unsynced { background: #fdf9f0; border-color: #f4ead2; }
 .at-sync-entry:hover .at-sync-line-unsynced { border-color: #ecd9af; }
+
+.at-sync-ic {
+  width: 22px; height: 22px; border-radius: 6px; flex-shrink: 0;
+  display: grid; place-items: center;
+}
+.at-sync-ic-rowCreated { background: #ece0fb; color: #6d28d9; }
+.at-sync-ic-rowLinked  { background: #d7eef9; color: #0b6f93; }
+.at-sync-ic-synced     { background: #ece0fb; color: #6d28d9; }
+.at-sync-ic-unsynced   { background: #faeccf; color: #b45309; }
+
 .at-sync-text {
   font-size: 12.5px; color: #2c3849;
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0;
 }
 .at-sync-text b { color: #0f1623; font-weight: 600; }
 .at-sync-spacer { flex: 1 1 auto; min-width: 8px; }
-.at-sync-actor { color: var(--color-dark); font-weight: 600; font-size: 12px; white-space: nowrap; }
-.at-sync-ts { font-variant-numeric: tabular-nums; color: #7d8ba0; font-size: 11px; white-space: nowrap; }
+.at-sync-actor { color: var(--color-dark); font-weight: 600; font-size: 12px; white-space: nowrap; flex-shrink: 0; }
+.at-sync-ts { font-variant-numeric: tabular-nums; color: #7d8ba0; font-size: 11px; white-space: nowrap; flex-shrink: 0; }
 
-/* Collapsed run of consecutive auto-syncs */
+/* Collapsed run of consecutive auto-syncs — type-neutral summary, per-outcome expanded items */
 .at-run-entry { padding: 4px 0; }
 .at-run-wrap {
-  border: 1px solid #ece4f9; border-radius: 8px;
-  background: #faf8fe; overflow: hidden; min-width: 0; width: 100%;
+  border: 1px solid #e3e7ee; border-radius: 8px;
+  background: #f8f9fc; overflow: hidden; min-width: 0; width: 100%;
 }
 .at-run-summary {
-  display: flex; align-items: center; gap: 9px;
+  display: flex; align-items: center; gap: 10px;
   width: 100%; text-align: left; font: inherit; font-family: inherit;
-  background: transparent; border: 0; cursor: pointer; padding: 8px 12px;
+  background: transparent; border: 0; cursor: pointer; padding: 7px 11px 7px 8px;
 }
-.at-run-summary:hover { background: #f4eefc; }
+.at-run-summary:hover { background: #f0f2f7; }
+.at-run-ic {
+  width: 22px; height: 22px; border-radius: 6px; flex-shrink: 0;
+  background: #e8ebf1; color: #5a6a7e;
+  display: grid; place-items: center;
+}
 .at-run-count { font-size: 12.5px; font-weight: 600; color: #0f1623; white-space: nowrap; }
+.at-run-breakdown {
+  font-size: 11px; color: #5a6a7e; white-space: nowrap;
+  padding-left: 8px; border-left: 1px solid #e3e7ee;
+}
 .at-run-range { font-size: 11px; color: #7d8ba0; font-variant-numeric: tabular-nums; white-space: nowrap; }
 .at-run-toggle {
   display: inline-flex; align-items: center; gap: 4px;
-  font-size: 11.5px; font-weight: 600; color: #6d28d9; white-space: nowrap;
+  font-size: 11.5px; font-weight: 600; color: #5a6a7e; white-space: nowrap; flex-shrink: 0;
 }
 .at-run-chevron { transition: transform .15s; }
 .at-run-summary.is-open .at-run-chevron { transform: rotate(180deg); }
 .at-run-list {
-  list-style: none; margin: 0; padding: 2px 12px 8px 14px;
-  border-top: 1px solid #ece4f9;
+  list-style: none; margin: 0; padding: 2px 11px 8px 11px;
+  border-top: 1px solid #eef1f6;
 }
 .at-run-item { display: flex; align-items: center; gap: 9px; padding: 5px 0; }
-.at-run-bullet { width: 5px; height: 5px; border-radius: 50%; flex-shrink: 0; }
+.at-run-ic-sm {
+  width: 18px; height: 18px; border-radius: 5px; flex-shrink: 0;
+  display: grid; place-items: center;
+}
 .at-run-item-text {
   font-size: 12px; color: #2c3849;
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0;
 }
 .at-run-item-text b { color: #0f1623; font-weight: 600; }
-.at-run-item-actor { color: #5a6a7e; font-weight: 600; font-size: 11.5px; white-space: nowrap; }
-.at-run-item-ts { color: #7d8ba0; font-size: 11px; font-variant-numeric: tabular-nums; white-space: nowrap; }
+.at-run-item-actor { color: #5a6a7e; font-weight: 600; font-size: 11.5px; white-space: nowrap; flex-shrink: 0; }
+.at-run-item-ts { color: #7d8ba0; font-size: 11px; font-variant-numeric: tabular-nums; white-space: nowrap; flex-shrink: 0; }
 
 /* =================== Inline Editing Modals (iem-) =================== */
 :root {

--- a/js/audit_trail.js
+++ b/js/audit_trail.js
@@ -18,9 +18,14 @@
     'net_30':           { label: 'Field Edited',     color: '#2563eb', bg: '#e8f0fc', fg: '#1d4ed8', group: 'edits'    },
     // Quote lifecycle events. 'quote_created' is a Status-group marker; sync events live
     // in their own 'sync' group and render as compact single-line rows (see at-sync-*).
+    // Write-once model: the app either CREATES a brand-new pipeline row (violet) or LINKS to
+    // one that already exists (cyan) — never overwriting. 'break_sync' (amber) is unchanged.
+    // 'sheetOp' drives the row tint + glyph; legacy 'sync_to_sheet' rows render as generic synced.
     'quote_created':    { label: 'Quote Created',   color: '#16a34a', bg: '#e8f6ec', fg: '#15803d', group: 'status' },
-    'sync_to_sheet':    { label: 'Synced',          color: '#7c3aed', bg: '#f1ebfc', fg: '#6d28d9', group: 'sync', syncType: 'synced'   },
-    'break_sync':       { label: 'Unsynced',        color: '#d97706', bg: '#fdf1de', fg: '#b45309', group: 'sync', syncType: 'unsynced' }
+    'sheet_row_created':{ label: 'Created in sheet', color: '#7c3aed', bg: '#f3eefe', fg: '#6d28d9', group: 'sync', syncType: 'synced',   sheetOp: 'rowCreated' },
+    'sheet_row_linked': { label: 'Linked to row',    color: '#0e8fbf', bg: '#e7f4fb', fg: '#0b6f93', group: 'sync', syncType: 'synced',   sheetOp: 'rowLinked'  },
+    'sync_to_sheet':    { label: 'Synced',           color: '#7c3aed', bg: '#f1ebfc', fg: '#6d28d9', group: 'sync', syncType: 'synced',   sheetOp: 'synced'     },
+    'break_sync':       { label: 'Unsynced',         color: '#d97706', bg: '#fdf1de', fg: '#b45309', group: 'sync', syncType: 'unsynced', sheetOp: 'unsynced'   }
   };
   var AT_DEFAULT = { label: 'Modified', color: '#2563eb', bg: '#e8f0fc', fg: '#1d4ed8', group: 'edits' };
 
@@ -169,19 +174,32 @@
     return units;
   }
 
+  // Distinct glyph per sync outcome so a reader can tell at a glance whether the app wrote a
+  // brand-new row (sheet-plus), attached to an existing one (link), or removed it (unlink).
+  // Legacy 'synced' rows fall back to a refresh glyph.
+  function atSyncGlyph(op, size) {
+    size = size || 14;
+    var open = '<svg width="' + size + '" height="' + size + '" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">';
+    var paths = {
+      rowCreated: '<rect x="3" y="3" width="18" height="18" rx="2"/><line x1="3" y1="8.5" x2="21" y2="8.5"/><line x1="12" y1="12" x2="12" y2="18"/><line x1="9" y1="15" x2="15" y2="15"/>',
+      rowLinked:  '<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>',
+      unsynced:   '<path d="M18.84 12.25l1.72-1.71a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M5.17 11.75l-1.71 1.71a5 5 0 0 0 7.07 7.07l1.71-1.71"/><line x1="2" y1="2" x2="22" y2="22"/>',
+      synced:     '<polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/>'
+    };
+    return open + (paths[op] || paths.synced) + '</svg>';
+  }
+
   function atRenderSyncEntry(e, showLine) {
-    var t = atType(e.action_type);
+    var t  = atType(e.action_type);
+    var op = t.sheetOp || 'synced';
     var shadow = '0 0 0 3px #fff,0 0 0 4px ' + t.color + '33';
-    var lineClass = t.syncType === 'unsynced' ? ' at-sync-line-unsynced' : '';
     return '<li class="at-entry at-sync-entry">' +
       '<div class="at-rail">' +
         '<span class="at-dot at-dot-sm" style="background:' + t.color + ';box-shadow:' + shadow + '"></span>' +
         (showLine ? '<span class="at-line"></span>' : '') +
       '</div>' +
-      '<div class="at-sync-line' + lineClass + '">' +
-        '<span class="at-badge" style="background:' + t.bg + ';color:' + t.fg + '">' +
-          '<span class="at-badge-dot" style="background:' + t.color + '"></span>' + t.label +
-        '</span>' +
+      '<div class="at-sync-line at-sync-line-' + op + '">' +
+        '<span class="at-sync-ic at-sync-ic-' + op + '">' + atSyncGlyph(op) + '</span>' +
         '<span class="at-sync-text">' + e.audit_trail + '</span>' +
         '<span class="at-sync-spacer"></span>' +
         '<span class="at-sync-actor">' + atEsc(e.username) + '</span>' +
@@ -190,30 +208,42 @@
     '</li>';
   }
 
+  // Collapsed run of consecutive automatic syncs. The summary is type-neutral with a
+  // breakdown ("2 created · 1 linked"); expanded items keep their own create/link accent so
+  // the two outcomes stay distinguishable even inside the run.
   function atRenderSyncRun(items, showLine) {
-    var t = atType('sync_to_sheet');
-    var shadow = '0 0 0 3px #fff,0 0 0 4px ' + t.color + '33';
+    var dotColor = '#94a3b8';
+    var shadow   = '0 0 0 3px #fff,0 0 0 4px rgba(148,163,184,0.25)';
     var newest = items[0], oldest = items[items.length - 1];
+
+    var created = items.filter(function (e) { return atType(e.action_type).sheetOp === 'rowCreated'; }).length;
+    var linked  = items.filter(function (e) { return atType(e.action_type).sheetOp === 'rowLinked';  }).length;
+    var parts = [];
+    if (created) { parts.push(created + ' created'); }
+    if (linked)  { parts.push(linked  + ' linked');  }
+    var breakdown = parts.join(' · ');
+
     var listItems = items.map(function (e) {
+      var op = atType(e.action_type).sheetOp || 'synced';
       return '<li class="at-run-item">' +
-        '<span class="at-run-bullet" style="background:' + t.color + '"></span>' +
+        '<span class="at-run-ic-sm at-sync-ic-' + op + '">' + atSyncGlyph(op, 11) + '</span>' +
         '<span class="at-run-item-text">' + e.audit_trail + '</span>' +
         '<span class="at-sync-spacer"></span>' +
         '<span class="at-run-item-actor">' + atEsc(e.username) + '</span>' +
         '<span class="at-run-item-ts">' + atEsc(atTimeShort(e.created_date)) + '</span>' +
       '</li>';
     }).join('');
+
     return '<li class="at-entry at-run-entry">' +
       '<div class="at-rail">' +
-        '<span class="at-dot at-dot-sm" style="background:' + t.color + ';box-shadow:' + shadow + '"></span>' +
+        '<span class="at-dot at-dot-sm at-dot-run" style="background:' + dotColor + ';box-shadow:' + shadow + '"></span>' +
         (showLine ? '<span class="at-line"></span>' : '') +
       '</div>' +
       '<div class="at-run-wrap">' +
         '<button type="button" class="at-run-summary">' +
-          '<span class="at-badge" style="background:' + t.bg + ';color:' + t.fg + '">' +
-            '<span class="at-badge-dot" style="background:' + t.color + '"></span>' + t.label +
-          '</span>' +
+          '<span class="at-run-ic">' + atSyncGlyph('synced', 13) + '</span>' +
           '<span class="at-run-count">' + items.length + ' automatic syncs</span>' +
+          (breakdown ? '<span class="at-run-breakdown">' + breakdown + '</span>' : '') +
           '<span class="at-run-range">' + atEsc(atTimeShort(oldest.created_date)) + ' &ndash; ' + atEsc(atTimeShort(newest.created_date)) + '</span>' +
           '<span class="at-sync-spacer"></span>' +
           '<span class="at-run-toggle"><span class="at-run-toggle-text">Show all</span>' +

--- a/js/sheet_sync.js
+++ b/js/sheet_sync.js
@@ -24,7 +24,11 @@
     syncing: '<path d="M3 12a9 9 0 1 0 3-6.7"/><polyline points="3 4 3 9 8 9"/>',
   };
 
-  function setTone(tone, syncAtText) {
+  // Write-once outcome → status label. Both read as "synced" (green), but say what actually
+  // happened: the app created a brand-new pipeline row or linked to an existing one.
+  const OUTCOME_LABEL = { created: 'Created in sheet', linked: 'Linked to row' };
+
+  function setTone(tone, syncAtText, labelOverride) {
     const t = TONES[tone] || TONES.never;
 
     // Block class
@@ -42,7 +46,7 @@
     const statusEl = block.querySelector('.ss-block-status');
     if (statusEl) {
       statusEl.className = `ss-block-status ss-block-status-${tone}`;
-      statusEl.textContent = t.label;
+      statusEl.textContent = labelOverride || t.label;
     }
 
     // Meta line (last synced / last attempted)
@@ -125,7 +129,7 @@
       .then(function (res) { return res.json(); })
       .then(function (data) {
         if (data.success) {
-          setTone('synced', data.sync_at);
+          setTone('synced', data.sync_at, OUTCOME_LABEL[data.outcome]);
           if (breakBtn) breakBtn.style.display = '';
         } else {
           setTone('failed', null);

--- a/plantillas/quote/validacion_registro_cotizacion.inc.php
+++ b/plantillas/quote/validacion_registro_cotizacion.inc.php
@@ -119,9 +119,18 @@ function createAndInsertQuote($validador, $usuario_designado) {
     try {
       $designatedUsername = $_POST['usuario_designado'];
       $insertedQuote = RepositorioRfq::obtener_cotizacion_por_id(Conexion::obtener_conexion(), $id_rfq);
-      $sheetRow = SheetSyncService::appendRow($insertedQuote, $designatedUsername);
-      SheetSyncRepository::updateSyncStatus(Conexion::obtener_conexion(), $id_rfq, 'synced', $sheetRow);
-      AuditTrailRepository::sync_to_sheet_audit_trail(Conexion::obtener_conexion(), $id_rfq);
+      // Write-once: link to the quote's row if it's already in the sheet, otherwise create it.
+      $result   = SheetSyncService::createOrLink($insertedQuote, $designatedUsername);
+      $sheetRow = $result['row'];
+      $outcome  = $result['outcome'];
+      if ($outcome !== null) {
+        SheetSyncRepository::updateSyncStatus(Conexion::obtener_conexion(), $id_rfq, 'synced', $sheetRow);
+        if ($outcome === 'created') {
+          AuditTrailRepository::sheet_row_created_audit_trail(Conexion::obtener_conexion(), $id_rfq);
+        } else {
+          AuditTrailRepository::sheet_row_linked_audit_trail(Conexion::obtener_conexion(), $id_rfq);
+        }
+      }
     } catch (Exception $syncEx) {
       SheetSyncRepository::updateSyncStatus(Conexion::obtener_conexion(), $id_rfq, 'failed');
       error_log('Sheet sync error on create: ' . $syncEx->getMessage());

--- a/scripts/quote/save_information.php
+++ b/scripts/quote/save_information.php
@@ -55,15 +55,32 @@ if (isset($_POST['save_information'])) {
       $updatedQuote = RepositorioRfq::obtener_cotizacion_por_id($conexion, $_POST['id_rfq']);
       if ($updatedQuote && (int)$updatedQuote->getSyncToSheet() === 1) {
         $designatedUsername = $_POST['usuario_designado'];
-        if ($updatedQuote->getSheetRow()) {
-          // syncRow self-heals a stale pointer and returns the row it actually wrote.
-          $writtenRow = SheetSyncService::syncRow($updatedQuote->getSheetRow(), $updatedQuote, $designatedUsername);
-        } else {
-          // Flagged to sync but no row yet (e.g. a prior append failed) — append (dedup-safe).
-          $writtenRow = SheetSyncService::appendRow($updatedQuote, $designatedUsername);
+        $priorRow    = $updatedQuote->getSheetRow();
+        $priorStatus = $updatedQuote->getSheetSyncStatus();
+
+        // Write-once: create the row if this quote isn't in the sheet, otherwise link to the
+        // existing row and write NOTHING. An ordinary edit of an already-linked quote makes
+        // zero Graph writes and leaves every cell untouched.
+        $result     = SheetSyncService::createOrLink($updatedQuote, $designatedUsername);
+        $writtenRow = $result['row'] ?? $priorRow;
+        $outcome    = $result['outcome'];
+
+        // Only stamp status / bump the timestamp / log an audit event when the link is newly
+        // established (created, or linked to a row this quote wasn't pointed at). A no-op edit
+        // produces no Sync-tab noise and doesn't move "last synced".
+        $established = $outcome !== null
+          && ($outcome === 'created'
+              || (string)$priorRow !== (string)$writtenRow
+              || $priorStatus !== 'synced');
+
+        if ($established) {
+          SheetSyncRepository::updateSyncStatus($conexion, $_POST['id_rfq'], 'synced', $writtenRow);
+          if ($outcome === 'created') {
+            AuditTrailRepository::sheet_row_created_audit_trail($conexion, $_POST['id_rfq']);
+          } else {
+            AuditTrailRepository::sheet_row_linked_audit_trail($conexion, $_POST['id_rfq']);
+          }
         }
-        SheetSyncRepository::updateSyncStatus($conexion, $_POST['id_rfq'], 'synced', $writtenRow);
-        AuditTrailRepository::sync_to_sheet_audit_trail($conexion, $_POST['id_rfq']);
       }
     } catch (Exception $syncEx) {
       SheetSyncRepository::updateSyncStatus($conexion, $_POST['id_rfq'], 'failed');

--- a/scripts/quote/sync_to_sheet.php
+++ b/scripts/quote/sync_to_sheet.php
@@ -29,26 +29,49 @@ try {
   $usuario = RepositorioUsuario::obtener_usuario_por_id($conexion, $quote->obtener_usuario_designado());
   $designatedUsername = $usuario ? $usuario->obtener_nombre_usuario() : '';
 
+  // Capture the pre-sync linkage so we can tell whether this sync establishes something new
+  // (worth a timestamp bump + audit event) or is a no-op re-affirmation of an existing link.
+  $priorRow    = $quote->getSheetRow();
+  $priorStatus = $quote->getSheetSyncStatus();
+
   Conexion::cerrar_conexion();
 
-  if ($quote->getSheetRow()) {
-    // Row already exists — re-write all columns so any edited fields are reflected.
-    // syncRow self-heals a stale pointer and returns the row it actually wrote.
-    $sheetRow = SheetSyncService::syncRow($quote->getSheetRow(), $quote, $designatedUsername);
-  } else {
-    // No row yet — append (duplicate-safe)
-    $sheetRow = SheetSyncService::appendRow($quote, $designatedUsername);
-  }
+  // Write-once: create the row if the quote isn't in the sheet, otherwise link to it
+  // (writing nothing). Never overwrites an existing row.
+  $result   = SheetSyncService::createOrLink($quote, $designatedUsername);
+  $sheetRow = $result['row'] ?? $priorRow;
+  $outcome  = $result['outcome'];
 
   Conexion::abrir_conexion();
-  SheetSyncRepository::updateSyncStatus(Conexion::obtener_conexion(), $id_rfq, 'synced', $sheetRow);
-  // Manually syncing also turns the per-quote flag on, so future edits auto-sync.
-  SheetSyncRepository::setSyncToSheet(Conexion::obtener_conexion(), $id_rfq, 1);
-  AuditTrailRepository::sync_to_sheet_audit_trail(Conexion::obtener_conexion(), $id_rfq);
-  $syncAt = date('M j, Y \a\t g:i A');
+  $conexion = Conexion::obtener_conexion();
+  // Manually syncing always turns the per-quote flag on, so future edits keep it represented.
+  SheetSyncRepository::setSyncToSheet($conexion, $id_rfq, 1);
+
+  // Only stamp the status / bump sheet_sync_at / log an audit event when the link is newly
+  // established — re-syncing a quote that's already linked to the same row is a no-op.
+  $established = $outcome !== null
+    && ($outcome === 'created'
+        || (string)$priorRow !== (string)$sheetRow
+        || $priorStatus !== 'synced');
+
+  if ($established) {
+    SheetSyncRepository::updateSyncStatus($conexion, $id_rfq, 'synced', $sheetRow);
+    if ($outcome === 'created') {
+      AuditTrailRepository::sheet_row_created_audit_trail($conexion, $id_rfq);
+    } else {
+      AuditTrailRepository::sheet_row_linked_audit_trail($conexion, $id_rfq);
+    }
+    $syncAt = date('M j, Y \a\t g:i A');
+  } else {
+    // Keep the existing "Last synced" time; nothing changed.
+    $existing = SheetSyncRepository::getSyncInfo($conexion, $id_rfq);
+    $syncAt = !empty($existing['sheet_sync_at'])
+      ? date('M j, Y \a\t g:i A', strtotime($existing['sheet_sync_at']))
+      : date('M j, Y \a\t g:i A');
+  }
   Conexion::cerrar_conexion();
 
-  echo json_encode(['success' => true, 'sync_at' => $syncAt, 'sheet_row' => $sheetRow]);
+  echo json_encode(['success' => true, 'sync_at' => $syncAt, 'sheet_row' => $sheetRow, 'outcome' => $outcome]);
 } catch (Exception $e) {
   error_log('Sheet sync error (manual): ' . $e->getMessage());
   try {

--- a/tests/php/sheet_sync_audit_test.php
+++ b/tests/php/sheet_sync_audit_test.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Integration test for the Write-Once Sheet Sync audit helpers on AuditTrailRepository:
+ *   - sheet_row_created_audit_trail -> action_type 'sheet_row_created' (Sync group, "Created in sheet")
+ *   - sheet_row_linked_audit_trail  -> action_type 'sheet_row_linked'  (Sync group, "Linked to existing row")
+ *
+ * The write-once model replaces the single generic "Synced" event with two distinguishable
+ * outcomes: the app either CREATED a brand-new pipeline row or LINKED to one that already
+ * existed (writing nothing). Each helper mirrors sync_to_sheet_audit_trail: it derives
+ * username/id from $_SESSION['user'] and writes one row through insert_audit_trail.
+ *
+ * The test stubs the session user, inserts a quote, calls each helper, reads back the rows,
+ * then ROLLS BACK so nothing persists.
+ *
+ * Run:  docker exec lamp-php83 php /var/www/html/rfq/tests/php/sheet_sync_audit_test.php
+ */
+
+$root = __DIR__ . '/../../';
+require_once $root . 'app/Bootstrap/config.inc.php';
+require_once $root . 'app/Bootstrap/Conexion.inc.php';
+require_once $root . 'app/Quote/AuditTrail.inc.php';
+require_once $root . 'app/Comment/RepositorioComment.inc.php';
+require_once $root . 'app/Quote/AuditTrailRepository.inc.php';
+
+$pass = 0; $fail = 0;
+function check($label, $expected, $actual) {
+  global $pass, $fail;
+  $ok = $expected === $actual;
+  if ($ok) { $pass++; echo "  PASS  $label\n"; }
+  else     { $fail++; echo "  FAIL  $label — expected " . var_export($expected, true) . ", got " . var_export($actual, true) . "\n"; }
+}
+
+/** Minimal stand-in for the logged-in user the helpers read from the session. */
+class FakeSessionUser {
+  private $id; private $name;
+  public function __construct($id, $name) { $this->id = $id; $this->name = $name; }
+  public function obtener_id() { return $this->id; }
+  public function obtener_nombre_usuario() { return $this->name; }
+}
+$_SESSION['user'] = new FakeSessionUser(7, 'RSantos');
+
+$conexion = Conexion::obtener_conexion();
+
+function insertQuote($conexion, array $o = []) {
+  $f = array_merge([
+    'id_usuario' => 1, 'usuario_designado' => 1, 'canal' => 'AUDITTEST',
+    'email_code' => 'SYNC-' . uniqid(), 'type_of_bid' => 'IT',
+    'issue_date' => '01/01/1999', 'end_date' => '01/01/1999', 'status' => 0, 'completado' => 0,
+    'comments' => 'No comments', 'award' => 0, 'payment_terms' => 'Net 30',
+    'address' => '', 'ship_to' => '', 'ship_via' => '', 'taxes' => 0, 'profit' => 0,
+    'additional' => '', 'shipping_cost' => 0, 'shipping' => '', 'fullfillment' => 0,
+    'contract_number' => '', 'total_price' => 0,
+    'invoice' => 0, 'submitted_invoice' => 0, 'deleted' => 0, 'name' => 'Sync Test',
+  ], $o);
+  $cols = array_keys($f);
+  $ph = array_map(fn($c) => ':' . $c, $cols);
+  $sql = 'INSERT INTO rfq (' . implode(',', $cols) . ') VALUES (' . implode(',', $ph) . ')';
+  $stmt = $conexion->prepare($sql);
+  foreach ($f as $c => $v) { $stmt->bindValue(':' . $c, $v); }
+  $stmt->execute();
+  return (int)$conexion->lastInsertId();
+}
+
+/** Read back the audit rows for a quote, newest first. */
+function readAudit($conexion, $id_rfq) {
+  $stmt = $conexion->prepare('SELECT username, action_type, id_user, audit_trail FROM audit_trails WHERE id_rfq = :id ORDER BY id DESC');
+  $stmt->bindValue(':id', $id_rfq, PDO::PARAM_INT);
+  $stmt->execute();
+  return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+$conexion->beginTransaction();
+try {
+  $id_rfq = insertQuote($conexion);
+
+  echo "[sheet_row_created]\n";
+  AuditTrailRepository::sheet_row_created_audit_trail($conexion, $id_rfq);
+  $rows = readAudit($conexion, $id_rfq);
+  check('one row written', 1, count($rows));
+  check('action_type = sheet_row_created', 'sheet_row_created', $rows[0]['action_type']);
+  check('username from session', 'RSantos', $rows[0]['username']);
+  check('id_user from session', '7', (string)$rows[0]['id_user']);
+  check('message mentions Created', true, stripos($rows[0]['audit_trail'], 'Created') !== false);
+
+  echo "[sheet_row_linked]\n";
+  AuditTrailRepository::sheet_row_linked_audit_trail($conexion, $id_rfq);
+  $rows = readAudit($conexion, $id_rfq);
+  check('two rows total', 2, count($rows));
+  check('newest action_type = sheet_row_linked', 'sheet_row_linked', $rows[0]['action_type']);
+  check('message mentions Linked', true, stripos($rows[0]['audit_trail'], 'Linked') !== false);
+
+  echo "[both belong to the Sync group, distinct from break_sync]\n";
+  AuditTrailRepository::break_sync_audit_trail($conexion, $id_rfq);
+  $rows = readAudit($conexion, $id_rfq);
+  check('three rows total', 3, count($rows));
+  check('newest action_type = break_sync', 'break_sync', $rows[0]['action_type']);
+  $types = array_map(fn($r) => $r['action_type'], $rows);
+  check('all three sync action types present', true,
+    in_array('sheet_row_created', $types, true)
+    && in_array('sheet_row_linked', $types, true)
+    && in_array('break_sync', $types, true));
+
+} finally {
+  $conexion->rollBack();
+}
+
+echo "\n==== $pass passed, $fail failed ====\n";
+exit($fail === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Implements the **Audit Trail.html** design handoff, which is the visible surface of the planned **Write-Once Sheet Sync** feature. Sync becomes **create-or-link** and strictly non-destructive: the app appends a pipeline row only when the quote id is absent from column A, otherwise it links to the existing row and writes nothing. It never overwrites or deletes a row.

## Audit Trail → Sync tab (the design)

- The single generic "Synced" row is split into two distinct compact rows with colored icon chips + distinct glyphs: **Created row in sheet** (violet, sheet-plus) and **Linked to existing row** (cyan, link).
- **Unsynced** stays amber (unlink); legacy `sync_to_sheet` rows still render (violet "Synced").
- 3+ consecutive automatic syncs still collapse into a **type-neutral "N automatic syncs"** run, now with a `2 created · 1 linked` breakdown; expanded items keep their per-outcome accent.

## Backend (create-or-link engine)

- `SheetSyncService::createOrLink()` — decides presence by scanning **column A**, links (writes nothing) if found, appends a fresh row if absent, returns `row` + `outcome`.
- New `AuditTrailRepository` helpers: `sheet_row_created_audit_trail` / `sheet_row_linked_audit_trail`.
- All three sync paths (create, on-save auto-sync, manual button) route through `createOrLink` and **log only on establishment** — a no-op edit of an already-linked quote makes **zero** Graph writes, no `sheet_sync_at` bump, no audit row.
- `sync_to_sheet.php` returns `outcome`; `sheet_sync.js` reflects it in the status label.

## Notes / decisions

- No schema change — reuses existing columns; new `action_type` strings fit the existing `VARCHAR(50)`.
- The destructive paths the feature wanted retired (`deleteRow` / row-shifting) already had **no callers**; `copyRfq` already starts copies unsynced. Old `syncRow`/`appendRow`/`deleteRow` are left in place but unused (marked superseded) — lower risk in production.
- Skipped the prototype's "Manual" tag + auto-only run filtering (the spec only requires the two distinguishable events + existing collapse behavior).
- The separate *SharePoint Sheet Sync.html* toast redesign was out of scope (only Audit Trail.html was requested); did the minimal label tweak it implies.

## Testing

- `tests/php/sheet_sync_audit_test.php` — TDD red→green, transaction-isolated (11 assertions).
- Headless render check of the real `js/audit_trail.js` (19 checks): Created/Linked/Unsynced tints + glyphs, run collapse + breakdown.
- Full existing PHP suite green (lifecycle audit, pipeline metrics, annual awards — 82 assertions total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)