### PR TITLE
feat: add advanced quote search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 | 3-Year Annual Awards Comparison (Charts tab annual cards: rolling current + 2 prior years) | built | — |
 | Quote Lifecycle Audit Events (audit-trail entries on quote create / sync / unsync, surfaced via the Audit Trail modal's Sync tab) | built | — |
 | Write-Once Sheet Sync (app creates a sheet row if missing but never overwrites/deletes an existing one — sync becomes create-or-link) | built | — |
+| Advanced Quote Search (Advanced toggle + filter panel on Search Quotes, Status pill column) | built | — |
 
 ## Environment
 
@@ -36,7 +37,7 @@ composer install
 
 **Generate users:** Visit `/genera_usuario` route.
 
-There are no automated tests or lint commands.
+**Tests:** PHP integration tests in `tests/php/` (`docker exec lamp-php83 php /var/www/html/rfq/tests/php/<file>`), Node unit tests in `tests/js/` (`node --test`), Playwright E2E in `tests/specs/` (`cd tests && PW_CHANNEL=chrome npx playwright test`). No lint commands.
 
 ## Architecture
 
@@ -187,3 +188,11 @@ Interactive ApexCharts report at `perfil/reports/pipeline_metrics` (sidebar entr
 Dashboard `perfil/charts` (`plantillas/utilities/charts.inc.php` + `js/main_charts.js`, **Chart.js** — not the ApexCharts pipeline page). The two Annual Awards cards (by Count `#ganados_anuales_chart`, by Amount `#monto_ganados_anual_chart`) compare a **rolling** window — current year + 2 prior — as grouped monthly columns. Endpoint `scripts/utilities/main_charts.php` builds `[Y-2, Y-1, Y]` and returns `annual_awards_years` (per year: totals + 12 monthly points) from `RepositorioRfq::getAnnualAwardsDataByMonthForYears($conn, $years)`. JS builds the 3 datasets and the 3-row legend (newest first) into `#annual_awards_*_legend`. Ramp oldest→newest: `#aebccb`, `#5e83a4`, `#13A8F0`. The per-user Completed/Awards cards are separate (current vs last month). Each **hides users with no activity in either month** (filtered independently per card via `activeUserSeries()` in `js/main_charts.js`; JSON counts `Number()`-coerced). That helper is unit-tested (`node --test tests/js/charts_filter.test.js`); the jQuery bootstrap is `typeof $`-guarded so the file stays requirable under Node.
 
 **Counts awards by AWARD DATE** (leadership decision — "when we won"): year **and** month bucket on `fecha_award` (NOT `issue_date`), matching the per-user Awards card; "awarded" = `award = 1` (`fecha_award` is stamped only when a bid is awarded — see `set_award`); value = product + services subtotal. This **deliberately differs** from the issue-date Bid Pipeline Metrics page — the two answer different questions (when-won vs issued-this-year conversion) and need not reconcile. Awards lacking a `fecha_award` don't appear. Test: `tests/php/annual_awards_test.php`.
+
+### Advanced Quote Search
+
+Search Quotes (`perfil/search_quotes`) has an **Advanced** toggle beside the keyword input. On: filter panel expands (status multi-select over the 10 pipeline buckets, designated user, type of bid, type of contract, date range with Created/Submitted/Awarded field selector, price min/max, client, state — AND-combined, keyword optional), Partial Invoices card hides, and the Quotes table gains a **Status pill** column. Off: filters reset, page identical to basic. Empty advanced search = all non-deleted quotes; inverted ranges = empty state, no error.
+
+- **Backend:** `RepositorioRfq::getAdvancedSearchedQuotes` / `getAdvancedSearchedQuotesCount` — a separate pair so the basic-mode queries stay untouched. Derived status reuses `PipelineMetricsRepository::STATUS_CASE` verbatim (filter counts match the pipeline chart); price filters compare product + services total; date filters exclude NULLs by construction. Same endpoint `utilities/search_quotes` with `advanced=1` + `statuses[]`/`f_*` params (whitelisted in `advancedSearchWhere`).
+- **Frontend:** dropdowns server-rendered in `search_quotes.inc.php` (active users, `type_of_bids`, `type_of_contracts`); status vocabulary emitted as `window.SQ_STATUSES` (keys/colors from `PipelineMetricsRepository::STATUSES`, labels per design). `js/searchQuotes.js` swaps DataTable column sets (inserts/removes the Status `<th>`) when toggling modes. `sq-*` CSS namespace at the bottom of `estilos.css`.
+- **Tests:** `tests/php/advanced_search_test.php` (35 assertions, transaction-isolated, client-marker scoping); `tests/specs/10-advanced-search.spec.js` (Playwright). Playwright on hosts without a bundled-chromium build: run with `PW_CHANNEL=chrome` to use system Google Chrome.

--- a/app/Quote/RepositorioRfq.inc.php
+++ b/app/Quote/RepositorioRfq.inc.php
@@ -1827,6 +1827,214 @@ class RepositorioRfq {
     return $sentencia->fetchColumn();
   }
 
+  /* ---- Advanced Quote Search (Search Quotes page, advanced mode) ----
+     Separate from the basic-mode pair above so basic behavior stays untouched.
+     derived_status reuses PipelineMetricsRepository::STATUS_CASE verbatim so the
+     status filter always agrees with the Bid Pipeline Metrics chart.
+     total_price = product total + services subtotal (same semantics as basic). */
+
+  private static function advancedSearchSubquery() {
+    return "
+      SELECT rfq.id,
+        rfq.email_code,
+        u.nombre_usuario,
+        rfq.type_of_bid,
+        rfq.type_of_contract,
+        rfq.usuario_designado,
+        rfq.comments,
+        rfq.contract_number,
+        rfq.city,
+        rfq.zip_code,
+        rfq.state,
+        rfq.client,
+        rfq.shipping_address,
+        rfq.special_requirements,
+        rfq.created_at,
+        rfq.fecha_submitted,
+        rfq.fecha_award,
+        COALESCE(SUM(COALESCE(s.total_price, 0)) + COALESCE(rfq.total_price, 0), 0) AS total_price,
+        " . PipelineMetricsRepository::STATUS_CASE . " AS derived_status
+      FROM rfq
+        LEFT JOIN usuarios u ON rfq.usuario_designado = u.id
+        LEFT JOIN services s ON rfq.id = s.id_rfq
+      WHERE rfq.deleted = 0
+      GROUP BY rfq.id";
+  }
+
+  /** Builds [whereSql, params] over the sq subquery for keyword + filters (AND-combined). */
+  private static function advancedSearchWhere($search_term, array $filters) {
+    $clauses = [];
+    $params = [];
+
+    if (trim((string)$search_term) !== '') {
+      $params[':search_term'] = '%' . $search_term . '%';
+      $clauses[] = "(
+        sq.nombre_usuario LIKE :search_term
+        OR sq.email_code LIKE :search_term
+        OR sq.type_of_bid LIKE :search_term
+        OR sq.comments LIKE :search_term
+        OR sq.total_price LIKE :search_term
+        OR sq.contract_number LIKE :search_term
+        OR sq.city LIKE :search_term
+        OR sq.zip_code LIKE :search_term
+        OR sq.state LIKE :search_term
+        OR sq.client LIKE :search_term
+        OR sq.shipping_address LIKE :search_term
+        OR sq.special_requirements LIKE :search_term
+        OR sq.id LIKE :search_term
+        OR EXISTS (
+          SELECT 1 FROM item i
+          WHERE i.id_rfq = sq.id
+            AND (i.provider_menor LIKE :search_term
+              OR i.brand LIKE :search_term
+              OR i.brand_project LIKE :search_term
+              OR i.part_number LIKE :search_term
+              OR i.part_number_project LIKE :search_term
+              OR i.description LIKE :search_term
+              OR i.description_project LIKE :search_term
+              OR i.comments LIKE :search_term)
+        )
+        OR EXISTS (
+          SELECT 1 FROM services svc
+          WHERE svc.id_rfq = sq.id AND svc.description LIKE :search_term
+        )
+        OR EXISTS (
+          SELECT 1 FROM subitems si
+            JOIN item i ON si.id_item = i.id
+          WHERE i.id_rfq = sq.id
+            AND (si.provider_menor LIKE :search_term
+              OR si.brand LIKE :search_term
+              OR si.brand_project LIKE :search_term
+              OR si.part_number LIKE :search_term
+              OR si.part_number_project LIKE :search_term
+              OR si.description LIKE :search_term
+              OR si.description_project LIKE :search_term
+              OR si.comments LIKE :search_term)
+        )
+      )";
+    }
+
+    $valid_statuses = array_column(PipelineMetricsRepository::STATUSES, 'key');
+    $statuses = array_values(array_intersect((array)($filters['statuses'] ?? []), $valid_statuses));
+    if (count($statuses)) {
+      $ph = [];
+      foreach ($statuses as $i => $st) {
+        $ph[] = ":status_$i";
+        $params[":status_$i"] = $st;
+      }
+      $clauses[] = 'sq.derived_status IN (' . implode(', ', $ph) . ')';
+    }
+
+    if (!empty($filters['user'])) {
+      $clauses[] = 'sq.usuario_designado = :f_user';
+      $params[':f_user'] = (int)$filters['user'];
+    }
+    if (!empty($filters['bid_type'])) {
+      $clauses[] = 'sq.type_of_bid = :f_bid_type';
+      $params[':f_bid_type'] = $filters['bid_type'];
+    }
+    if (!empty($filters['contract_type'])) {
+      $clauses[] = 'sq.type_of_contract = :f_contract_type';
+      $params[':f_contract_type'] = $filters['contract_type'];
+    }
+
+    // created_at is DATETIME, the other two are DATE — compare on DATE() uniformly.
+    $date_columns = [
+      'created' => 'DATE(sq.created_at)',
+      'submitted' => 'sq.fecha_submitted',
+      'awarded' => 'sq.fecha_award',
+    ];
+    $date_expr = $date_columns[$filters['date_field'] ?? 'created'] ?? $date_columns['created'];
+    if (!empty($filters['date_from'])) {
+      $clauses[] = "$date_expr >= :f_date_from";
+      $params[':f_date_from'] = $filters['date_from'];
+    }
+    if (!empty($filters['date_to'])) {
+      $clauses[] = "$date_expr <= :f_date_to";
+      $params[':f_date_to'] = $filters['date_to'];
+    }
+
+    if (isset($filters['price_min']) && $filters['price_min'] !== '') {
+      $clauses[] = 'sq.total_price >= :f_price_min';
+      $params[':f_price_min'] = (float)$filters['price_min'];
+    }
+    if (isset($filters['price_max']) && $filters['price_max'] !== '') {
+      $clauses[] = 'sq.total_price <= :f_price_max';
+      $params[':f_price_max'] = (float)$filters['price_max'];
+    }
+
+    if (!empty($filters['client']) && trim($filters['client']) !== '') {
+      $clauses[] = 'sq.client LIKE :f_client';
+      $params[':f_client'] = '%' . trim($filters['client']) . '%';
+    }
+    if (!empty($filters['state']) && trim($filters['state']) !== '') {
+      $clauses[] = 'sq.state LIKE :f_state';
+      $params[':f_state'] = '%' . trim($filters['state']) . '%';
+    }
+
+    $where = count($clauses) ? 'WHERE ' . implode("\n          AND ", $clauses) : '';
+    return [$where, $params];
+  }
+
+  public static function getAdvancedSearchedQuotes($conexion, $start, $length, $sort_column_index, $sort_direction, $search_term, array $filters) {
+    $data = [];
+    // Advanced table column order (Status inserted at index 5).
+    $sort_columns = [
+      0 => 'sq.id', 1 => 'sq.email_code', 2 => 'sq.contract_number', 3 => 'sq.nombre_usuario',
+      4 => 'sq.type_of_bid', 5 => 'sq.derived_status', 6 => 'sq.comments', 7 => 'sq.total_price',
+    ];
+    $sort_column = $sort_columns[$sort_column_index] ?? 'sq.id';
+    $sort_direction = strtolower($sort_direction) === 'asc' ? 'asc' : 'desc';
+    $start = (int)$start;
+    $length = (int)$length;
+    if (isset($conexion)) {
+      try {
+        list($where, $params) = self::advancedSearchWhere($search_term, $filters);
+        $sql = "
+        SELECT sq.id, sq.email_code, sq.contract_number, sq.nombre_usuario,
+          sq.type_of_bid, sq.derived_status, sq.comments, sq.total_price,
+          NULL AS options
+        FROM (" . self::advancedSearchSubquery() . ") AS sq
+        $where
+        ORDER BY {$sort_column} {$sort_direction} LIMIT {$start}, {$length}
+        ";
+        $sentencia = $conexion->prepare($sql);
+        foreach ($params as $key => $value) {
+          $sentencia->bindValue($key, $value);
+        }
+        $sentencia->execute();
+        while ($row = $sentencia->fetch(PDO::FETCH_ASSOC)) {
+          $data[] = $row;
+        }
+      } catch (PDOException $ex) {
+        error_log('getAdvancedSearchedQuotes error: ' . $ex->getMessage());
+      }
+    }
+    return $data;
+  }
+
+  public static function getAdvancedSearchedQuotesCount($conexion, $search_term, array $filters) {
+    if (isset($conexion)) {
+      try {
+        list($where, $params) = self::advancedSearchWhere($search_term, $filters);
+        $sql = "
+        SELECT COUNT(*)
+        FROM (" . self::advancedSearchSubquery() . ") AS sq
+        $where
+        ";
+        $sentencia = $conexion->prepare($sql);
+        foreach ($params as $key => $value) {
+          $sentencia->bindValue($key, $value);
+        }
+        $sentencia->execute();
+        return (int)$sentencia->fetchColumn();
+      } catch (PDOException $ex) {
+        error_log('getAdvancedSearchedQuotesCount error: ' . $ex->getMessage());
+      }
+    }
+    return 0;
+  }
+
   public static function getSearchedInvoices($conexion, $start, $length, $sort_column_index, $sort_direction, $search_term) {
     $data = [];
     $search_term = '%' . $search_term . '%';

--- a/css/estilos.css
+++ b/css/estilos.css
@@ -3052,3 +3052,176 @@ h3.text-info.text-center .fa-exclamation-circle {
 .ss-choice-title { font-size: 13.5px; font-weight: 700; color: #0f1623; }
 .ss-choice-sub { font-size: 11.5px; color: #5a6a7e; line-height: 1.4; }
 @media (max-width: 520px) { .ss-choice-grid { grid-template-columns: 1fr; } }
+
+/* =========================================================================
+   Advanced Quote Search (Search Quotes page) — sq-* namespace
+   ========================================================================= */
+
+/* ---- search row ---- */
+.sq-search-row { display: flex; gap: 10px; align-items: stretch; }
+.sq-kw-wrap {
+  flex: 1; display: flex; align-items: center; gap: 9px;
+  border: 1px solid #e3e7ee; border-radius: 9px; background: #fff;
+  padding: 0 12px; height: 42px;
+  transition: border-color .14s, box-shadow .14s;
+}
+.sq-kw-wrap:focus-within { border-color: #2db4e8; box-shadow: 0 0 0 3px rgba(45,180,232,0.18); }
+.sq-kw-icon { color: #7d8ba0; display: grid; place-items: center; flex-shrink: 0; }
+.sq-kw-input { flex: 1; border: 0; outline: 0; background: transparent; font: inherit; font-size: 14px; color: #0f1623; min-width: 0; }
+.sq-kw-input::placeholder { color: #7d8ba0; }
+
+.sq-adv-btn {
+  flex-shrink: 0; height: 42px; padding: 0 16px;
+  display: inline-flex; align-items: center; gap: 8px;
+  border: 1px solid #e3e7ee; border-radius: 9px; background: #fff;
+  font: inherit; font-size: 13px; font-weight: 600; color: #2c3849; cursor: pointer;
+  transition: background .14s, border-color .14s, color .14s, box-shadow .14s;
+}
+.sq-adv-btn:hover { background: #f4f6fa; border-color: #c7d0dd; }
+.sq-adv-btn:focus { outline: 0; box-shadow: 0 0 0 3px rgba(45,180,232,0.18); }
+.sq-adv-btn.is-on {
+  background: #1d2a3d; border-color: #1d2a3d; color: #fff;
+  box-shadow: 0 1px 3px rgba(15,22,35,0.25);
+}
+.sq-adv-btn.is-on:hover { background: #2a3a52; border-color: #2a3a52; }
+.sq-adv-count {
+  min-width: 18px; height: 18px; padding: 0 5px; border-radius: 9px;
+  background: #2db4e8; color: #fff; font-size: 11px; font-weight: 700;
+  display: grid; place-items: center;
+}
+.sq-search-help { font-size: 11.5px; color: #7d8ba0; margin: 8px 2px 0; }
+
+/* ---- advanced panel reveal ---- */
+.sq-filters-reveal {
+  overflow: hidden; max-height: 0; opacity: 0;
+  transition: max-height .28s ease, opacity .2s ease;
+}
+.sq-filters-reveal.is-open { max-height: 620px; opacity: 1; }
+/* once expanded, allow the status dropdown menu to overflow the panel */
+.sq-filters-reveal.is-settled { overflow: visible; }
+.sq-filters-inner { min-height: 0; }
+@media (prefers-reduced-motion: reduce) { .sq-filters-reveal { transition: none; } }
+
+.sq-filters { margin-top: 14px; border-top: 1px solid #eef1f6; padding-top: 12px; }
+.sq-filters-head { display: flex; align-items: center; gap: 10px; margin-bottom: 12px; }
+.sq-filters-title { font-size: 11px; text-transform: uppercase; letter-spacing: 0.07em; font-weight: 700; color: #2c3849; }
+.sq-filters-hint { font-size: 11.5px; color: #7d8ba0; }
+.sq-clear-btn {
+  margin-left: auto; height: 28px; padding: 0 10px;
+  display: inline-flex; align-items: center; gap: 6px;
+  border: 1px solid transparent; border-radius: 6px; background: transparent;
+  font: inherit; font-size: 12px; font-weight: 600; color: #5a6a7e; cursor: pointer;
+  transition: background .12s, color .12s;
+}
+.sq-clear-btn:hover:not(:disabled) { background: #f4f6fa; color: #2c3849; }
+.sq-clear-btn:disabled { opacity: 0.45; cursor: default; }
+
+.sq-filters-grid {
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px 16px;
+  padding-bottom: 4px;
+}
+.sq-field { display: flex; flex-direction: column; gap: 6px; min-width: 0; margin-bottom: 0; }
+.sq-field-dates { grid-column: span 2; }
+.sq-field-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; font-weight: 700; color: #2c3849; }
+.sq-field-label-row { display: flex; align-items: center; justify-content: space-between; gap: 8px; min-height: 18px; }
+@media (max-width: 991px) { .sq-filters-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 575px) { .sq-filters-grid { grid-template-columns: 1fr; } .sq-field-dates { grid-column: auto; } }
+
+.sq-input {
+  height: 36px; padding: 0 10px; width: 100%;
+  border: 1px solid #e3e7ee; border-radius: 8px; background: #fff;
+  font: inherit; font-size: 13px; color: #0f1623;
+  transition: border-color .12s, box-shadow .12s;
+}
+.sq-input::placeholder { color: #7d8ba0; }
+.sq-input:hover { border-color: #c7d0dd; }
+.sq-input:focus { outline: 0; border-color: #2db4e8; box-shadow: 0 0 0 3px rgba(45,180,232,0.18); }
+input.sq-input[type="date"] { font-size: 12.5px; color: #2c3849; }
+
+.sq-select-wrap { position: relative; display: block; }
+.sq-select { appearance: none; -webkit-appearance: none; padding-right: 30px; cursor: pointer; }
+.sq-select.is-placeholder { color: #7d8ba0; }
+.sq-select-caret { position: absolute; right: 9px; top: 50%; transform: translateY(-50%); color: #7d8ba0; pointer-events: none; display: grid; place-items: center; font-size: 11px; }
+
+.sq-range { display: flex; align-items: center; gap: 8px; min-width: 0; }
+.sq-range .sq-input { min-width: 0; }
+.sq-range-sep { font-size: 11.5px; color: #7d8ba0; flex-shrink: 0; }
+.sq-money-wrap { position: relative; flex: 1; min-width: 0; display: block; }
+.sq-money-sign { position: absolute; left: 10px; top: 50%; transform: translateY(-50%); font-size: 12.5px; color: #7d8ba0; pointer-events: none; }
+.sq-money { padding-left: 22px; }
+.sq-money::-webkit-outer-spin-button, .sq-money::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+
+/* segmented date-field selector */
+.sq-seg { display: inline-flex; gap: 2px; background: #f4f6fa; border: 1px solid #eef1f6; border-radius: 7px; padding: 2px; }
+.sq-seg-btn {
+  height: 20px; padding: 0 8px; border: 0; border-radius: 5px; background: transparent;
+  font: inherit; font-size: 10.5px; font-weight: 600; color: #5a6a7e; cursor: pointer;
+  transition: background .12s, color .12s, box-shadow .12s;
+}
+.sq-seg-btn:hover { color: #2c3849; }
+.sq-seg-btn.is-on { background: #fff; color: #1d2a3d; box-shadow: 0 1px 2px rgba(15,22,35,0.08); }
+
+/* ---- status multi-select ---- */
+.sq-ms-wrap { position: relative; }
+.sq-ms-trigger {
+  display: flex; align-items: center; gap: 8px; padding-right: 30px;
+  text-align: left; cursor: pointer; position: relative; overflow: hidden;
+}
+.sq-ms-trigger.is-open { border-color: #2db4e8; box-shadow: 0 0 0 3px rgba(45,180,232,0.18); }
+.sq-ms-summary { display: flex; align-items: center; min-width: 0; overflow: hidden; }
+.sq-ms-placeholder { color: #7d8ba0; font-size: 13px; }
+.sq-ms-pills { display: flex; align-items: center; gap: 5px; min-width: 0; overflow: hidden; }
+.sq-ms-more { font-size: 11.5px; font-weight: 600; color: #5a6a7e; white-space: nowrap; }
+.sq-ms-menu {
+  position: absolute; z-index: 30; top: calc(100% + 6px); left: 0; min-width: 270px;
+  background: #fff; border: 1px solid #e3e7ee; border-radius: 10px;
+  box-shadow: 0 14px 36px -10px rgba(15,22,35,0.22), 0 4px 12px -4px rgba(15,22,35,0.12);
+  overflow: hidden;
+}
+.sq-ms-menu-head {
+  display: flex; align-items: center; justify-content: space-between; gap: 8px;
+  padding: 9px 12px; border-bottom: 1px solid #eef1f6; background: #fafbfd;
+  font-size: 11.5px; color: #5a6a7e; font-weight: 500;
+}
+.sq-ms-clear { border: 0; background: transparent; font: inherit; font-size: 11.5px; font-weight: 700; color: #1aa2dc; cursor: pointer; padding: 0; }
+.sq-ms-clear:hover { text-decoration: underline; }
+.sq-ms-list { max-height: 264px; overflow-y: auto; padding: 5px; }
+.sq-ms-opt {
+  display: flex; align-items: center; gap: 9px; width: 100%;
+  padding: 7px 8px; border: 0; border-radius: 7px; background: transparent;
+  font: inherit; font-size: 12.5px; color: #2c3849; cursor: pointer; text-align: left;
+  transition: background .1s;
+}
+.sq-ms-opt:hover { background: #f4f6fa; }
+.sq-ms-opt.is-on { color: #0f1623; font-weight: 600; }
+.sq-ms-check {
+  flex-shrink: 0; width: 16px; height: 16px; border-radius: 5px;
+  border: 1.5px solid #aab4c2; background: #fff; color: #fff;
+  display: grid; place-items: center; font-size: 9px;
+  transition: background .12s, border-color .12s;
+}
+.sq-ms-check .fas { visibility: hidden; }
+.sq-ms-check.is-on { background: #2db4e8; border-color: #2db4e8; }
+.sq-ms-check.is-on .fas { visibility: visible; }
+.sq-ms-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+.sq-ms-label { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+/* ---- status pills ---- */
+.sq-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  height: 22px; padding: 0 9px; border-radius: 12px; white-space: nowrap;
+  font-size: 11.5px; font-weight: 600; line-height: 1;
+  color: color-mix(in srgb, var(--c) 78%, #0f1623);
+  background: color-mix(in srgb, var(--c) 11%, white);
+  border: 1px solid color-mix(in srgb, var(--c) 26%, white);
+}
+.sq-pill-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--c); flex-shrink: 0; }
+
+/* ---- advanced empty state (inside DataTables zeroRecords cell) ---- */
+.sq-empty { padding: 28px 24px; text-align: center; }
+.sq-empty-icon {
+  width: 54px; height: 54px; margin: 0 auto 12px; border-radius: 50%;
+  background: #f4f6fa; color: #aab4c2; display: grid; place-items: center; font-size: 22px;
+}
+.sq-empty-title { font-size: 14px; font-weight: 600; color: #0f1623; }
+.sq-empty-sub { font-size: 12.5px; color: #7d8ba0; margin-top: 3px; max-width: 340px; margin-left: auto; margin-right: auto; }

--- a/js/searchQuotes.js
+++ b/js/searchQuotes.js
@@ -6,6 +6,111 @@ $(document).ready(function () {
   let dataTable = null;
   let invoicesTable = null;
 
+  // ---------- advanced mode state ----------
+  let advanced = false;
+  const statusByKey = {};
+  (window.SQ_STATUSES || []).forEach(function (s) { statusByKey[s.key] = s; });
+  let selectedStatuses = [];
+
+  const $toggle = $('#sq_adv_toggle');
+  const $reveal = $('#sq_filters_reveal');
+  const $searchCol = $('#sq_search_col');
+  const $invoicesCard = $('#sq_invoices_card');
+  const $help = $('#sq_search_help');
+  const $advCount = $('#sq_adv_count');
+
+  function pillHtml(key) {
+    const st = statusByKey[key];
+    if (!st) return key || '—';
+    return `<span class="sq-pill" style="--c:${st.color}"><span class="sq-pill-dot"></span>${st.label}</span>`;
+  }
+
+  function collectFilters() {
+    return {
+      statuses: selectedStatuses.slice(),
+      f_user: $('#sq_f_user').val() || '',
+      f_bid_type: $('#sq_f_bid_type').val() || '',
+      f_contract_type: $('#sq_f_contract_type').val() || '',
+      f_date_field: $('#sq_date_field_seg .is-on').data('date-field') || 'created',
+      f_date_from: $('#sq_f_date_from').val() || '',
+      f_date_to: $('#sq_f_date_to').val() || '',
+      f_price_min: $('#sq_f_price_min').val() || '',
+      f_price_max: $('#sq_f_price_max').val() || '',
+      f_client: $('#sq_f_client').val().trim(),
+      f_state: $('#sq_f_state').val().trim(),
+    };
+  }
+
+  function activeFilterCount() {
+    const f = collectFilters();
+    let n = 0;
+    if (f.statuses.length) n++;
+    if (f.f_user) n++;
+    if (f.f_bid_type) n++;
+    if (f.f_contract_type) n++;
+    if (f.f_date_from || f.f_date_to) n++;
+    if (f.f_price_min !== '' || f.f_price_max !== '') n++;
+    if (f.f_client) n++;
+    if (f.f_state) n++;
+    return n;
+  }
+
+  function refreshFilterChrome() {
+    const n = activeFilterCount();
+    $advCount.toggle(advanced && n > 0).text(n);
+    $('#sq_filters_hint').text(n === 0 ? 'No filters set — all quotes match' : n + ' filter' + (n > 1 ? 's' : '') + ' applied');
+    $('#sq_clear_filters').prop('disabled', n === 0);
+  }
+
+  // ---------- status multi-select ----------
+  const $msTrigger = $('#sq_status_trigger');
+  const $msMenu = $('#sq_status_menu');
+
+  function renderStatusSummary() {
+    const $summary = $('#sq_status_summary');
+    if (selectedStatuses.length === 0) {
+      $summary.html('<span class="sq-ms-placeholder">Any status</span>');
+    } else if (selectedStatuses.length <= 2) {
+      $summary.html('<span class="sq-ms-pills">' + selectedStatuses.map(pillHtml).join('') + '</span>');
+    } else {
+      $summary.html('<span class="sq-ms-pills">' + pillHtml(selectedStatuses[0])
+        + '<span class="sq-ms-more">+' + (selectedStatuses.length - 1) + ' more</span></span>');
+    }
+    $('#sq_status_menu_count').text(selectedStatuses.length === 0 ? 'All statuses match' : selectedStatuses.length + ' selected');
+    $('#sq_status_clear').toggle(selectedStatuses.length > 0);
+    $msMenu.find('.sq-ms-opt').each(function () {
+      const on = selectedStatuses.indexOf($(this).data('status')) !== -1;
+      $(this).toggleClass('is-on', on).find('.sq-ms-check').toggleClass('is-on', on);
+    });
+  }
+
+  $msTrigger.on('click', function () {
+    const open = $msMenu.is(':visible');
+    $msMenu.toggle(!open);
+    $msTrigger.toggleClass('is-open', !open);
+  });
+  $(document).on('mousedown', function (e) {
+    if (!$(e.target).closest('#sq_status_field').length) {
+      $msMenu.hide();
+      $msTrigger.removeClass('is-open');
+    }
+  });
+  $msMenu.on('click', '.sq-ms-opt', function () {
+    const key = $(this).data('status');
+    const i = selectedStatuses.indexOf(key);
+    if (i === -1) selectedStatuses.push(key); else selectedStatuses.splice(i, 1);
+    renderStatusSummary();
+    refreshFilterChrome();
+    scheduleSearch();
+  });
+  $('#sq_status_clear').on('click', function () {
+    selectedStatuses = [];
+    renderStatusSummary();
+    refreshFilterChrome();
+    scheduleSearch();
+  });
+
+  // ---------- tables ----------
   function initializeInvoicesTable(searchTerm) {
     if (invoicesTable) {
       invoicesTable.destroy();
@@ -49,10 +154,59 @@ $(document).ready(function () {
     });
   }
 
-  function initializeDataTable(searchTerm) {
+  const optionsColumn = {
+    data: 'options',
+    orderable: false,
+    render: function (data, type, row) {
+      if (type === 'display') {
+        return `
+          <a class="btn btn-sm btn-secondary" data-toggle="tooltip" data-original-title="Proposal" href="/rfq/quote/proposal/${row.id}" target="_blank">
+            <i class="fa fa-file"></i>
+          </a>
+          <a class="btn btn-secondary btn-sm" data-toggle="tooltip" data-original-title="GSA Proposal" href="/rfq/quote/proposal_gsa/${row.id}" target="_blank">
+            <i class="fa fa-balance-scale"></i>
+          </a>
+          <a class="btn btn-secondary btn-sm" data-toggle="tooltip" data-original-title="Rooms" href="/rfq/quote/proposal_room/${row.id}" target="_blank">
+            <i class="fa fa-th"></i>
+          </a>
+        `;
+      }
+      return data;
+    },
+  };
+
+  const proposalColumn = {
+    data: 'id',
+    render: function (data, type) {
+      if (type === 'display') {
+        return `<a href="/rfq/perfil/quote/editar_cotizacion/${data}">${data}</a>`;
+      }
+      return data;
+    },
+  };
+
+  /** Quotes table thead must match the column defs: Status th only in advanced mode. */
+  function syncStatusHeader(show) {
+    const $thead = $('#tabla_busqueda thead tr');
+    const exists = $thead.find('th.sq-status-th').length > 0;
+    if (show && !exists) {
+      $('<th class="sq-status-th">Status</th>').insertAfter($thead.find('th').eq(4));
+    } else if (!show && exists) {
+      $thead.find('th.sq-status-th').remove();
+    }
+  }
+
+  function destroyQuotesTable() {
     if (dataTable) {
       dataTable.destroy();
+      dataTable = null;
+      $('#tabla_busqueda tbody').empty();
     }
+  }
+
+  function initializeDataTable(searchTerm) {
+    destroyQuotesTable();
+    syncStatusHeader(false);
     dataTable = $('#tabla_busqueda').DataTable({
       searching: false,
       processing: true,
@@ -64,63 +218,163 @@ $(document).ready(function () {
         data: { searchTerm },
       },
       columns: [
-        {
-          data: 'id',
-          render: function (data, type) {
-            if (type === 'display') {
-              return `<a href="/rfq/perfil/quote/editar_cotizacion/${data}">${data}</a>`;
-            }
-            return data;
-          },
-        },
+        proposalColumn,
         { data: 'email_code' },
         { data: 'contract_number', defaultContent: '—' },
         { data: 'nombre_usuario' },
         { data: 'type_of_bid' },
         { data: 'comments' },
         { data: 'total_price' },
-        {
-          data: 'options',
-          orderable: false,
-          render: function (data, type, row) {
-            if (type === 'display') {
-              return `
-                <a class="btn btn-sm btn-secondary" data-toggle="tooltip" data-original-title="Proposal" href="/rfq/quote/proposal/${row.id}" target="_blank">
-                  <i class="fa fa-file"></i>
-                </a>
-                <a class="btn btn-secondary btn-sm" data-toggle="tooltip" data-original-title="GSA Proposal" href="/rfq/quote/proposal_gsa/${row.id}" target="_blank">
-                  <i class="fa fa-balance-scale"></i>
-                </a>
-                <a class="btn btn-secondary btn-sm" data-toggle="tooltip" data-original-title="Rooms" href="/rfq/quote/proposal_room/${row.id}" target="_blank">
-                  <i class="fa fa-th"></i>
-                </a>
-              `;
-            }
-            return data;
-          },
-        },
+        optionsColumn,
       ],
     });
   }
 
+  function initializeAdvancedTable(searchTerm) {
+    destroyQuotesTable();
+    syncStatusHeader(true);
+    dataTable = $('#tabla_busqueda').DataTable({
+      searching: false,
+      processing: true,
+      serverSide: true,
+      pageLength: 10,
+      language: {
+        zeroRecords:
+          '<div class="sq-empty">' +
+          '<div class="sq-empty-icon"><i class="fas fa-inbox"></i></div>' +
+          '<div class="sq-empty-title">No matching records</div>' +
+          '<div class="sq-empty-sub">Try removing a filter or broadening the date or price range.</div>' +
+          '</div>',
+      },
+      ajax: {
+        url: '/rfq/utilities/search_quotes',
+        type: 'POST',
+        data: function (d) {
+          d.searchTerm = searchTerm;
+          d.advanced = '1';
+          const f = collectFilters();
+          Object.keys(f).forEach(function (k) { d[k] = f[k]; });
+        },
+      },
+      columns: [
+        proposalColumn,
+        { data: 'email_code' },
+        { data: 'contract_number', defaultContent: '—' },
+        { data: 'nombre_usuario' },
+        { data: 'type_of_bid' },
+        {
+          data: 'derived_status',
+          render: function (data, type) {
+            if (type === 'display') return pillHtml(data);
+            return data;
+          },
+        },
+        { data: 'comments' },
+        { data: 'total_price' },
+        optionsColumn,
+      ],
+    });
+  }
+
+  // ---------- search triggers ----------
   function triggerSearch() {
     const term = $input.val().trim();
-    if (term.length >= MIN_CHARS) {
+    if (advanced) {
+      // Keyword optional in advanced mode; below the minimum it's ignored.
+      initializeAdvancedTable(term.length >= MIN_CHARS ? term : '');
+    } else if (term.length >= MIN_CHARS) {
       initializeDataTable(term);
       initializeInvoicesTable(term);
     }
   }
 
-  // Live search with debounce
-  $input.on('input', function () {
+  function scheduleSearch() {
     clearTimeout(debounceTimer);
     debounceTimer = setTimeout(triggerSearch, DEBOUNCE_MS);
-  });
+  }
+
+  // Live search with debounce
+  $input.on('input', scheduleSearch);
 
   // Keep Enter key / button click working
   $('#search_quotes').on('submit', function (e) {
     e.preventDefault();
     clearTimeout(debounceTimer);
     triggerSearch();
+  });
+
+  // ---------- filter wiring ----------
+  $('#sq_f_user, #sq_f_bid_type, #sq_f_contract_type').on('change', function () {
+    $(this).toggleClass('is-placeholder', $(this).val() === '');
+    refreshFilterChrome();
+    scheduleSearch();
+  });
+  $('#sq_f_date_from, #sq_f_date_to').on('change', function () {
+    refreshFilterChrome();
+    scheduleSearch();
+  });
+  $('#sq_f_price_min, #sq_f_price_max, #sq_f_client, #sq_f_state').on('input', function () {
+    refreshFilterChrome();
+    scheduleSearch();
+  });
+  $('#sq_date_field_seg').on('click', '.sq-seg-btn', function () {
+    $('#sq_date_field_seg .sq-seg-btn').removeClass('is-on');
+    $(this).addClass('is-on');
+    refreshFilterChrome();
+    // Date field only matters when a range is set.
+    if ($('#sq_f_date_from').val() || $('#sq_f_date_to').val()) scheduleSearch();
+  });
+
+  function clearFilters() {
+    selectedStatuses = [];
+    renderStatusSummary();
+    $('#sq_f_user, #sq_f_bid_type, #sq_f_contract_type').val('').addClass('is-placeholder');
+    $('#sq_f_date_from, #sq_f_date_to, #sq_f_price_min, #sq_f_price_max, #sq_f_client, #sq_f_state').val('');
+    $('#sq_date_field_seg .sq-seg-btn').removeClass('is-on').filter('[data-date-field="created"]').addClass('is-on');
+    refreshFilterChrome();
+  }
+
+  $('#sq_clear_filters').on('click', function () {
+    clearFilters();
+    scheduleSearch();
+  });
+
+  // ---------- advanced toggle ----------
+  $reveal.on('transitionend', function (e) {
+    if (advanced && e.originalEvent.propertyName === 'max-height') {
+      $reveal.addClass('is-settled');
+    }
+  });
+
+  $toggle.on('click', function () {
+    advanced = !advanced;
+    clearTimeout(debounceTimer);
+    $toggle.toggleClass('is-on', advanced).attr('aria-expanded', advanced);
+    $reveal.toggleClass('is-open', advanced).removeClass('is-settled');
+    $searchCol.toggleClass('col-lg-6 col-md-8', !advanced).toggleClass('col-lg-11 col-xl-10', advanced);
+    $invoicesCard.toggle(!advanced);
+    $input.attr('placeholder', advanced ? 'Keyword (optional in advanced search)' : 'Type at least 3 characters to search...');
+    $help.text(advanced
+      ? 'Keyword is optional — combine any filters below, or leave everything blank to browse all quotes.'
+      : 'Results appear automatically after 3 characters.');
+
+    if (advanced) {
+      if (invoicesTable) {
+        invoicesTable.destroy();
+        invoicesTable = null;
+        $('#tabla_invoices tbody').empty();
+      }
+      refreshFilterChrome();
+      triggerSearch();
+    } else {
+      // Collapsing resets filters and restores the basic page.
+      clearFilters();
+      $advCount.hide();
+      $msMenu.hide();
+      $msTrigger.removeClass('is-open');
+      destroyQuotesTable();
+      syncStatusHeader(false);
+      triggerSearch();
+    }
   });
 });

--- a/plantillas/utilities/search_quotes.inc.php
+++ b/plantillas/utilities/search_quotes.inc.php
@@ -1,3 +1,23 @@
+<?php
+// Advanced-search dropdown data + status vocabulary.
+// Keys/colors mirror PipelineMetricsRepository::STATUSES so the filter always
+// agrees with the Bid Pipeline Metrics chart; labels follow the design handoff.
+$sq_conexion = Conexion::obtener_conexion();
+$sq_users = RepositorioUsuario::getAllActiveUsers($sq_conexion);
+usort($sq_users, fn($a, $b) => strcasecmp($a['nombre_usuario'], $b['nombre_usuario']));
+$sq_bid_types = TypeOfBidRepository::get_all($sq_conexion);
+$sq_contract_types = TypeOfContractRepository::get_all($sq_conexion);
+
+$sq_label_overrides = [
+  'submitted_ss'       => 'Submitted (Sources Sought)',
+  'no_award_pricing'   => 'No Award - Pricing',
+  'no_award_technical' => 'No Award - Technical',
+];
+$sq_statuses = array_map(function ($s) use ($sq_label_overrides) {
+  $s['label'] = $sq_label_overrides[$s['key']] ?? $s['label'];
+  return $s;
+}, PipelineMetricsRepository::STATUSES);
+?>
 <div class="content-wrapper">
 
   <div class="content-header page-header-bar">
@@ -12,17 +32,152 @@
 
       <!-- Search form -->
       <div class="row justify-content-center mb-4">
-        <div class="col-lg-6 col-md-8">
+        <div class="col-lg-6 col-md-8" id="sq_search_col" data-testid="search-card">
           <div class="card chart-card mb-0">
             <div class="card-body">
               <form id="search_quotes" role="form" method="post" action="">
-                <div class="input-group">
-                  <div class="input-group-prepend">
-                    <span class="input-group-text"><i class="fas fa-search"></i></span>
+                <div class="sq-search-row">
+                  <div class="sq-kw-wrap">
+                    <span class="sq-kw-icon"><i class="fas fa-search"></i></span>
+                    <input type="search" name="termino_busqueda" class="sq-kw-input" placeholder="Type at least 3 characters to search..." autofocus>
                   </div>
-                  <input type="search" name="termino_busqueda" class="form-control search-input" placeholder="Type at least 3 characters to search..." autofocus>
+                  <button type="button" class="sq-adv-btn" id="sq_adv_toggle" aria-expanded="false" data-testid="advanced-toggle">
+                    <i class="fas fa-sliders-h"></i>
+                    Advanced
+                    <span class="sq-adv-count" id="sq_adv_count" style="display:none;">0</span>
+                  </button>
                 </div>
-                <small class="form-text text-muted mt-1">Results appear automatically after 3 characters.</small>
+                <div class="sq-search-help" id="sq_search_help">Results appear automatically after 3 characters.</div>
+
+                <!-- Advanced filter panel -->
+                <div class="sq-filters-reveal" id="sq_filters_reveal" data-testid="advanced-filter-panel">
+                  <div class="sq-filters-inner">
+                    <div class="sq-filters">
+                      <div class="sq-filters-head">
+                        <span class="sq-filters-title">Filters</span>
+                        <span class="sq-filters-hint" id="sq_filters_hint">No filters set — all quotes match</span>
+                        <button type="button" class="sq-clear-btn" id="sq_clear_filters" disabled data-testid="clear-filters">
+                          <i class="fas fa-undo-alt"></i> Clear filters
+                        </button>
+                      </div>
+
+                      <div class="sq-filters-grid">
+
+                        <!-- Status multi-select -->
+                        <div class="sq-field" id="sq_status_field">
+                          <span class="sq-field-label">Status</span>
+                          <div class="sq-ms-wrap">
+                            <button type="button" class="sq-input sq-ms-trigger" id="sq_status_trigger" data-testid="status-filter">
+                              <span class="sq-ms-summary" id="sq_status_summary"><span class="sq-ms-placeholder">Any status</span></span>
+                              <span class="sq-select-caret"><i class="fas fa-chevron-down"></i></span>
+                            </button>
+                            <div class="sq-ms-menu" id="sq_status_menu" style="display:none;">
+                              <div class="sq-ms-menu-head">
+                                <span id="sq_status_menu_count">All statuses match</span>
+                                <button type="button" class="sq-ms-clear" id="sq_status_clear" style="display:none;">Clear</button>
+                              </div>
+                              <div class="sq-ms-list">
+                                <?php foreach ($sq_statuses as $s): ?>
+                                  <button type="button" class="sq-ms-opt" data-status="<?= $s['key']; ?>" data-testid="status-opt-<?= $s['key']; ?>">
+                                    <span class="sq-ms-check"><i class="fas fa-check"></i></span>
+                                    <span class="sq-ms-dot" style="background: <?= $s['color']; ?>;"></span>
+                                    <span class="sq-ms-label"><?= htmlspecialchars($s['label']); ?></span>
+                                  </button>
+                                <?php endforeach; ?>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+
+                        <!-- Designated user -->
+                        <label class="sq-field">
+                          <span class="sq-field-label">Designated User</span>
+                          <span class="sq-select-wrap">
+                            <select class="sq-input sq-select is-placeholder" id="sq_f_user" data-testid="user-filter">
+                              <option value="">Any user</option>
+                              <?php foreach ($sq_users as $u): ?>
+                                <option value="<?= (int)$u['id']; ?>"><?= htmlspecialchars($u['nombre_usuario']); ?></option>
+                              <?php endforeach; ?>
+                            </select>
+                            <span class="sq-select-caret"><i class="fas fa-chevron-down"></i></span>
+                          </span>
+                        </label>
+
+                        <!-- Type of bid -->
+                        <label class="sq-field">
+                          <span class="sq-field-label">Type of Bid</span>
+                          <span class="sq-select-wrap">
+                            <select class="sq-input sq-select is-placeholder" id="sq_f_bid_type" data-testid="bid-type-filter">
+                              <option value="">Any type</option>
+                              <?php foreach ($sq_bid_types as $tb): ?>
+                                <option value="<?= htmlspecialchars($tb->get_type_of_bid()); ?>"><?= htmlspecialchars($tb->get_type_of_bid()); ?></option>
+                              <?php endforeach; ?>
+                            </select>
+                            <span class="sq-select-caret"><i class="fas fa-chevron-down"></i></span>
+                          </span>
+                        </label>
+
+                        <!-- Type of contract -->
+                        <label class="sq-field">
+                          <span class="sq-field-label">Type of Contract</span>
+                          <span class="sq-select-wrap">
+                            <select class="sq-input sq-select is-placeholder" id="sq_f_contract_type" data-testid="contract-type-filter">
+                              <option value="">Any type</option>
+                              <?php foreach ($sq_contract_types as $tc): ?>
+                                <option value="<?= htmlspecialchars($tc->get_type_of_contract()); ?>"><?= htmlspecialchars($tc->get_type_of_contract()); ?></option>
+                              <?php endforeach; ?>
+                            </select>
+                            <span class="sq-select-caret"><i class="fas fa-chevron-down"></i></span>
+                          </span>
+                        </label>
+
+                        <!-- Date range + field selector -->
+                        <div class="sq-field sq-field-dates">
+                          <span class="sq-field-label-row">
+                            <span class="sq-field-label">Date range</span>
+                            <span class="sq-seg" role="radiogroup" aria-label="Date field" id="sq_date_field_seg">
+                              <button type="button" class="sq-seg-btn is-on" data-date-field="created">Created</button>
+                              <button type="button" class="sq-seg-btn" data-date-field="submitted">Submitted</button>
+                              <button type="button" class="sq-seg-btn" data-date-field="awarded">Awarded</button>
+                            </span>
+                          </span>
+                          <span class="sq-range">
+                            <input type="date" class="sq-input" id="sq_f_date_from" aria-label="From date" data-testid="date-from">
+                            <span class="sq-range-sep">to</span>
+                            <input type="date" class="sq-input" id="sq_f_date_to" aria-label="To date" data-testid="date-to">
+                          </span>
+                        </div>
+
+                        <!-- Total price range -->
+                        <div class="sq-field">
+                          <span class="sq-field-label">Total Price</span>
+                          <span class="sq-range">
+                            <span class="sq-money-wrap"><span class="sq-money-sign">$</span>
+                              <input type="number" min="0" class="sq-input sq-money" id="sq_f_price_min" placeholder="Min" data-testid="price-min">
+                            </span>
+                            <span class="sq-range-sep">to</span>
+                            <span class="sq-money-wrap"><span class="sq-money-sign">$</span>
+                              <input type="number" min="0" class="sq-input sq-money" id="sq_f_price_max" placeholder="Max" data-testid="price-max">
+                            </span>
+                          </span>
+                        </div>
+
+                        <!-- Client -->
+                        <label class="sq-field">
+                          <span class="sq-field-label">Client</span>
+                          <input type="text" class="sq-input" id="sq_f_client" placeholder="Client name contains…" data-testid="client-filter">
+                        </label>
+
+                        <!-- State -->
+                        <label class="sq-field">
+                          <span class="sq-field-label">State</span>
+                          <input type="text" class="sq-input" id="sq_f_state" placeholder="e.g. FL" data-testid="state-filter">
+                        </label>
+
+                      </div>
+                    </div>
+                  </div>
+                </div>
               </form>
             </div>
           </div>
@@ -30,7 +185,7 @@
       </div>
 
       <!-- Quotes results table -->
-      <div class="card chart-card mb-4">
+      <div class="card chart-card mb-4" data-testid="quotes-results-card">
         <div class="card-body">
           <p class="chart-card-label">Quotes</p>
           <table id="tabla_busqueda" class="table table-bordered table-hover">
@@ -52,7 +207,7 @@
       </div>
 
       <!-- Partial invoices results table -->
-      <div class="card chart-card">
+      <div class="card chart-card" id="sq_invoices_card" data-testid="partial-invoices-card">
         <div class="card-body">
           <p class="chart-card-label"><i class="fas fa-file-invoice-dollar mr-1"></i> Partial Invoices</p>
           <table id="tabla_invoices" class="table table-bordered table-hover">
@@ -73,4 +228,7 @@
   </section>
 </div>
 
+<script>
+  window.SQ_STATUSES = <?= json_encode($sq_statuses); ?>;
+</script>
 <script src="<?= RUTA_JS; ?>searchQuotes.js"></script>

--- a/scripts/utilities/search_quotes.php
+++ b/scripts/utilities/search_quotes.php
@@ -8,14 +8,33 @@ try {
   $sort_column_index = isset($_POST['order'][0]['column']) ? (int)$_POST['order'][0]['column'] : 0;
   $sort_direction = $_POST['order'][0]['dir'] ?? 'asc';
   $searchTerm = $_POST['searchTerm'] ?? '';
+  $advanced = ($_POST['advanced'] ?? '') === '1';
 
   // Open database connection
   Conexion::abrir_conexion();
   $conexion = Conexion::obtener_conexion();
 
-  // Fetch quotes and count data
-  $quotes = RepositorioRfq::getSearchedQuotesByChannel($conexion, $start, $length, $search, $sort_column_index, $sort_direction, $searchTerm);
-  $total_records = RepositorioRfq::getTotalSearchedQuotesByChannelCount($conexion, $searchTerm);
+  if ($advanced) {
+    // Advanced mode: keyword optional, filters AND-combined.
+    $filters = [
+      'statuses' => (array)($_POST['statuses'] ?? []),
+      'user' => $_POST['f_user'] ?? '',
+      'bid_type' => $_POST['f_bid_type'] ?? '',
+      'contract_type' => $_POST['f_contract_type'] ?? '',
+      'date_field' => $_POST['f_date_field'] ?? 'created',
+      'date_from' => $_POST['f_date_from'] ?? '',
+      'date_to' => $_POST['f_date_to'] ?? '',
+      'price_min' => $_POST['f_price_min'] ?? '',
+      'price_max' => $_POST['f_price_max'] ?? '',
+      'client' => $_POST['f_client'] ?? '',
+      'state' => $_POST['f_state'] ?? '',
+    ];
+    $quotes = RepositorioRfq::getAdvancedSearchedQuotes($conexion, $start, $length, $sort_column_index, $sort_direction, $searchTerm, $filters);
+    $total_records = RepositorioRfq::getAdvancedSearchedQuotesCount($conexion, $searchTerm, $filters);
+  } else {
+    $quotes = RepositorioRfq::getSearchedQuotesByChannel($conexion, $start, $length, $search, $sort_column_index, $sort_direction, $searchTerm);
+    $total_records = RepositorioRfq::getTotalSearchedQuotesByChannelCount($conexion, $searchTerm);
+  }
   $total_filtered_records = $total_records; // Assuming filtered and total counts are the same
 
   // Close database connection

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -8,7 +8,7 @@
       "name": "rfq-playwright-tests",
       "version": "1.0.0",
       "devDependencies": {
-        "@playwright/test": "^1.44.0",
+        "@playwright/test": "^1.60.0",
         "mysql2": "^3.10.0"
       }
     },
@@ -17,6 +17,7 @@
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
       "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.60.0"
       },
@@ -25,16 +26,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@types/node": {
-      "version": "25.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
-      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.21.0"
       }
     },
     "node_modules/aws-ssl-profiles": {
@@ -205,13 +196,6 @@
         "type": "github",
         "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
-      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
-      "dev": true,
-      "peer": true
     }
   }
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -9,7 +9,7 @@
     "report": "playwright show-report"
   },
   "devDependencies": {
-    "@playwright/test": "^1.44.0",
+    "@playwright/test": "^1.60.0",
     "mysql2": "^3.10.0"
   }
 }

--- a/tests/php/advanced_search_test.php
+++ b/tests/php/advanced_search_test.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Integration test for RepositorioRfq advanced search
+ * (getAdvancedSearchedQuotes / getAdvancedSearchedQuotesCount).
+ *
+ * Inserts a controlled set of quotes scoped by a unique client marker (the
+ * client filter doubles as the isolation fence, so every assertion also
+ * exercises AND-combination), runs the filtered queries, then ROLLS BACK.
+ *
+ * Run:  docker exec lamp-php83 php /var/www/html/rfq/tests/php/advanced_search_test.php
+ */
+
+$root = __DIR__ . '/../../';
+require_once $root . 'app/Bootstrap/config.inc.php';
+require_once $root . 'app/Bootstrap/Conexion.inc.php';
+require_once $root . 'app/Quote/Rfq.inc.php';
+require_once $root . 'app/Quote/RepositorioRfq.inc.php';
+require_once $root . 'app/Report/PipelineMetricsRepository.inc.php';
+
+$MARK = 'ADVTESTCLIENT';
+
+$pass = 0; $fail = 0;
+function check($label, $expected, $actual) {
+  global $pass, $fail;
+  $ok = $expected === $actual;
+  if ($ok) { $pass++; echo "  PASS  $label\n"; }
+  else     { $fail++; echo "  FAIL  $label — expected " . var_export($expected, true) . ", got " . var_export($actual, true) . "\n"; }
+}
+
+/** Base filter set: everything off except the isolation client marker. */
+function f(array $overrides = []) {
+  global $MARK;
+  return array_merge([
+    'statuses' => [], 'user' => '', 'bid_type' => '', 'contract_type' => '',
+    'date_field' => 'created', 'date_from' => '', 'date_to' => '',
+    'price_min' => '', 'price_max' => '', 'client' => $MARK, 'state' => '',
+  ], $overrides);
+}
+
+function advCount($conexion, $term, array $filters) {
+  return (int)RepositorioRfq::getAdvancedSearchedQuotesCount($conexion, $term, $filters);
+}
+function advRows($conexion, $term, array $filters) {
+  return RepositorioRfq::getAdvancedSearchedQuotes($conexion, 0, 50, 0, 'desc', $term, $filters);
+}
+
+$conexion = Conexion::obtener_conexion();
+
+function insertQuote($conexion, array $o) {
+  global $MARK;
+  $f = array_merge([
+    'id_usuario' => 1, 'usuario_designado' => 1, 'canal' => 'ADVTEST',
+    'email_code' => 'ADVTEST-' . uniqid(), 'type_of_bid' => 'IT',
+    'created_at' => '2099-03-15 00:00:00',
+    'issue_date' => '03/15/2099', 'end_date' => '03/15/2099', 'status' => 0, 'completado' => 0,
+    'comments' => 'No comments', 'award' => 0, 'payment_terms' => 'Net 30',
+    'address' => '', 'ship_to' => '', 'ship_via' => '', 'taxes' => 0, 'profit' => 0,
+    'additional' => '', 'shipping_cost' => 0, 'shipping' => '', 'fullfillment' => 0,
+    'contract_number' => '', 'sources_sought' => 0, 'total_price' => 0,
+    'invoice' => 0, 'submitted_invoice' => 0, 'deleted' => 0, 'name' => 'Adv Search Test',
+    'client' => $MARK, 'state' => 'FL', 'type_of_contract' => 'Purchase Order',
+  ], $o);
+  $cols = array_keys($f);
+  $ph = array_map(fn($c) => ':' . $c, $cols);
+  $sql = 'INSERT INTO rfq (' . implode(',', $cols) . ') VALUES (' . implode(',', $ph) . ')';
+  $stmt = $conexion->prepare($sql);
+  foreach ($f as $c => $v) { $stmt->bindValue(':' . $c, $v); }
+  $stmt->execute();
+  return (int)$conexion->lastInsertId();
+}
+
+function insertService($conexion, $id_rfq, $total_price) {
+  $stmt = $conexion->prepare('INSERT INTO services (id_rfq, description, quantity, unit_price, total_price)
+          VALUES (:id_rfq, :d, 1, :p, :p2)');
+  $stmt->bindValue(':id_rfq', $id_rfq, PDO::PARAM_INT);
+  $stmt->bindValue(':d', 'ADVTEST service');
+  $stmt->bindValue(':p', $total_price);
+  $stmt->bindValue(':p2', $total_price);
+  $stmt->execute();
+}
+
+$conexion->beginTransaction();
+try {
+  // ---- controlled dataset: 5 quotes, one per axis under test ----
+  $ids = [];
+  // award — IT / PO / FL, product 100 + service 50 = 150, full lifecycle dates
+  $ids['award'] = insertQuote($conexion, [
+    'award' => 1, 'status' => 1, 'completado' => 1, 'total_price' => 100,
+    'email_code' => 'ADVKW-XYZ123',
+    'fecha_submitted' => '2099-03-20', 'fecha_award' => '2099-04-01',
+  ]);
+  insertService($conexion, $ids['award'], 50);
+  // submitted — Services / GA, price 200
+  $ids['sub'] = insertQuote($conexion, [
+    'status' => 1, 'completado' => 1, 'total_price' => 200, 'type_of_bid' => 'Services',
+    'state' => 'GA', 'created_at' => '2099-05-10 00:00:00', 'fecha_submitted' => '2099-05-15',
+  ]);
+  // no bid — priced 0
+  $ids['nobid'] = insertQuote($conexion, [
+    'completado' => 1, 'comments' => 'No Bid', 'created_at' => '2099-06-01 00:00:00',
+  ]);
+  // tbd — TX / GSA Schedule / distinct designated user, price 300
+  $ids['tbd'] = insertQuote($conexion, [
+    'completado' => 0, 'total_price' => 300, 'state' => 'TX',
+    'type_of_contract' => 'GSA Schedule', 'usuario_designado' => 999999,
+    'created_at' => '2099-07-01 00:00:00',
+  ]);
+  // submitted sources-sought
+  $ids['ss'] = insertQuote($conexion, [
+    'status' => 1, 'completado' => 1, 'sources_sought' => 1, 'total_price' => 90,
+    'fecha_submitted' => '2099-03-25',
+  ]);
+  // deleted quote — must never appear
+  insertQuote($conexion, ['deleted' => 1]);
+
+  echo "[Isolation / no filters]\n";
+  check('client marker alone matches the 5 live test quotes', 5, advCount($conexion, '', f()));
+  check('deleted quotes are excluded', 5, count(advRows($conexion, '', f())));
+
+  echo "[Status filter]\n";
+  check('single status: award', 1, advCount($conexion, '', f(['statuses' => ['award']])));
+  $rows = advRows($conexion, '', f(['statuses' => ['award']]));
+  check('award row carries derived_status', 'award', $rows[0]['derived_status'] ?? null);
+  check('multi-select is a union (submitted+submitted_ss)', 2, advCount($conexion, '', f(['statuses' => ['submitted', 'submitted_ss']])));
+  check('status no_bid', 1, advCount($conexion, '', f(['statuses' => ['no_bid']])));
+  check('status tbd', 1, advCount($conexion, '', f(['statuses' => ['tbd']])));
+
+  echo "[Simple field filters]\n";
+  check('bid type IT', 4, advCount($conexion, '', f(['bid_type' => 'IT'])));  // award + nobid + tbd + ss
+  check('bid type Services', 1, advCount($conexion, '', f(['bid_type' => 'Services'])));
+  check('contract type GSA Schedule', 1, advCount($conexion, '', f(['contract_type' => 'GSA Schedule'])));
+  check('designated user', 1, advCount($conexion, '', f(['user' => '999999'])));
+  check('state LIKE (FL)', 3, advCount($conexion, '', f(['state' => 'FL'])));
+
+  echo "[Date range]\n";
+  check('created range May–Jun', 2, advCount($conexion, '', f(['date_from' => '2099-05-01', 'date_to' => '2099-06-30'])));
+  check('created from-only', 3, advCount($conexion, '', f(['date_from' => '2099-05-01'])));
+  check('submitted field: NULLs excluded', 3, advCount($conexion, '', f(['date_field' => 'submitted', 'date_from' => '2099-01-01'])));
+  check('awarded field: only the award', 1, advCount($conexion, '', f(['date_field' => 'awarded', 'date_from' => '2099-01-01'])));
+  check('inverted date range is empty, not an error', 0, advCount($conexion, '', f(['date_from' => '2099-12-31', 'date_to' => '2099-01-01'])));
+
+  echo "[Price range — product + services]\n";
+  check('min 150 includes the 100+50 award (services join)', 3, advCount($conexion, '', f(['price_min' => '150'])));
+  check('max 100 (0, 90 rows)', 2, advCount($conexion, '', f(['price_max' => '100'])));
+  check('inverted price range is empty, not an error', 0, advCount($conexion, '', f(['price_min' => '1000', 'price_max' => '10'])));
+  $rows = advRows($conexion, '', f(['statuses' => ['award']]));
+  check('row total_price = product + services', 150.0, (float)$rows[0]['total_price']);
+
+  echo "[Keyword + filters AND-combine]\n";
+  check('keyword alone (unique email_code)', 1, advCount($conexion, 'ADVKW-XYZ123', f()));
+  check('keyword + non-matching status = 0', 0, advCount($conexion, 'ADVKW-XYZ123', f(['statuses' => ['tbd']])));
+  check('keyword + matching status = 1', 1, advCount($conexion, 'ADVKW-XYZ123', f(['statuses' => ['award']])));
+
+  echo "[Pagination + ordering]\n";
+  $rows = advRows($conexion, '', f());
+  check('default order id desc (newest first)', $ids['ss'], (int)$rows[0]['id']);
+  $page = RepositorioRfq::getAdvancedSearchedQuotes($conexion, 0, 2, 0, 'desc', '', f());
+  check('LIMIT respected', 2, count($page));
+
+  echo "[Row shape]\n";
+  $row = advRows($conexion, '', f(['statuses' => ['submitted_ss']]))[0];
+  foreach (['id', 'email_code', 'contract_number', 'nombre_usuario', 'type_of_bid', 'comments', 'total_price', 'derived_status'] as $k) {
+    check("row has '$k'", true, array_key_exists($k, $row));
+  }
+  check('ss row derived_status', 'submitted_ss', $row['derived_status']);
+} finally {
+  $conexion->rollBack();
+}
+
+echo "\nRESULT: $pass passed, $fail failed\n";
+exit($fail === 0 ? 0 : 1);

--- a/tests/playwright.config.js
+++ b/tests/playwright.config.js
@@ -16,6 +16,9 @@ module.exports = defineConfig({
     baseURL: 'http://localhost/rfq',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
+    // Playwright's bundled chromium has no build for this host OS — set
+    // PW_CHANNEL=chrome to run against the system-installed Google Chrome.
+    channel: process.env.PW_CHANNEL || undefined,
   },
   projects: [
     {

--- a/tests/specs/10-advanced-search.spec.js
+++ b/tests/specs/10-advanced-search.spec.js
@@ -1,0 +1,94 @@
+const { test, expect } = require('@playwright/test');
+
+const PAGE = 'http://localhost/rfq/perfil/search_quotes';
+
+async function openAdvanced(page) {
+  await page.goto(PAGE);
+  await page.click('[data-testid="advanced-toggle"]');
+  await expect(page.locator('[data-testid="advanced-filter-panel"]')).toHaveClass(/is-open/);
+}
+
+/** Waits for the quotes DataTable to finish a server-side load. */
+async function waitForResults(page) {
+  await expect(page.locator('#tabla_busqueda_processing')).toBeHidden({ timeout: 15000 });
+  await expect(page.locator('#tabla_busqueda tbody tr').first()).toBeVisible({ timeout: 15000 });
+}
+
+test.describe('Advanced Quote Search', () => {
+  test('basic mode behaves as before: keyword search fills both tables', async ({ page }) => {
+    await page.goto(PAGE);
+    await expect(page.locator('[data-testid="advanced-filter-panel"]')).not.toHaveClass(/is-open/);
+    await expect(page.locator('[data-testid="partial-invoices-card"]')).toBeVisible();
+
+    await page.fill('[name="termino_busqueda"]', 'quote');
+    await waitForResults(page);
+    // No Status column in basic mode
+    await expect(page.locator('#tabla_busqueda thead th.sq-status-th')).toHaveCount(0);
+    await expect(page.locator('#tabla_invoices tbody tr').first()).toBeVisible();
+  });
+
+  test('advanced toggle opens panel, hides invoices, loads all quotes with Status pills', async ({ page }) => {
+    await openAdvanced(page);
+    await expect(page.locator('[data-testid="partial-invoices-card"]')).toBeHidden();
+    await waitForResults(page);
+
+    await expect(page.locator('#tabla_busqueda thead th.sq-status-th')).toHaveCount(1);
+    await expect(page.locator('#tabla_busqueda tbody .sq-pill').first()).toBeVisible();
+    // browsing with no filters and no keyword is valid
+    const info = await page.locator('#tabla_busqueda_info').innerText();
+    expect(info).toMatch(/of [\d,]+ entries/);
+  });
+
+  test('status filter narrows results to the selected bucket', async ({ page }) => {
+    await openAdvanced(page);
+    await waitForResults(page);
+
+    await page.click('[data-testid="status-filter"]');
+    await page.click('[data-testid="status-opt-award"]');
+    await page.click('h1.page-title'); // close the dropdown
+    await waitForResults(page);
+
+    const pills = page.locator('#tabla_busqueda tbody .sq-pill');
+    const n = await pills.count();
+    expect(n).toBeGreaterThan(0);
+    for (let i = 0; i < n; i++) {
+      await expect(pills.nth(i)).toHaveText('Award');
+    }
+    await expect(page.locator('#sq_adv_count')).toHaveText('1');
+  });
+
+  test('inverted price range shows the empty state, not an error', async ({ page }) => {
+    await openAdvanced(page);
+    await waitForResults(page);
+
+    await page.fill('[data-testid="price-min"]', '999999');
+    await page.fill('[data-testid="price-max"]', '1');
+    await expect(page.locator('#tabla_busqueda .sq-empty-title')).toHaveText('No matching records', { timeout: 15000 });
+  });
+
+  test('clear filters resets the panel and reloads', async ({ page }) => {
+    await openAdvanced(page);
+    await waitForResults(page);
+
+    await page.fill('[data-testid="state-filter"]', 'FL');
+    await expect(page.locator('#sq_adv_count')).toHaveText('1');
+    await page.click('[data-testid="clear-filters"]');
+    await expect(page.locator('#sq_adv_count')).toBeHidden();
+    await expect(page.locator('[data-testid="state-filter"]')).toHaveValue('');
+  });
+
+  test('toggling back to basic restores the page and resets filters', async ({ page }) => {
+    await openAdvanced(page);
+    await waitForResults(page);
+    await page.fill('[data-testid="client-filter"]', 'county');
+
+    await page.click('[data-testid="advanced-toggle"]');
+    await expect(page.locator('[data-testid="advanced-filter-panel"]')).not.toHaveClass(/is-open/);
+    await expect(page.locator('[data-testid="partial-invoices-card"]')).toBeVisible();
+    await expect(page.locator('#tabla_busqueda thead th.sq-status-th')).toHaveCount(0);
+
+    // reopening shows filters were reset
+    await page.click('[data-testid="advanced-toggle"]');
+    await expect(page.locator('[data-testid="client-filter"]')).toHaveValue('');
+  });
+});


### PR DESCRIPTION
## Summary

Adds an **Advanced** toggle to the Search Quotes page (`perfil/search_quotes`), implementing the Claude Design handoff for Advanced Quote Search.

- **Advanced mode:** expands a filter panel — status multi-select over the 10 pipeline buckets, designated user, type of bid, type of contract, date range with Created/Submitted/Awarded field selector, price min/max, client, state. Filters AND-combine; keyword becomes optional (empty advanced search browses all non-deleted quotes, paginated server-side).
- **Status pill column** appears in the results table, derived via `PipelineMetricsRepository::STATUS_CASE` verbatim so filter results always agree with the Bid Pipeline Metrics chart.
- **Partial Invoices card hides** in advanced mode; toggling back to basic resets all filters and restores the page exactly (basic mode hits the original, untouched queries).
- Edge cases per spec: inverted price/date ranges return the standard empty state (no error); active-filter count badge on the toggle.

## Implementation

- `RepositorioRfq::getAdvancedSearchedQuotes` / `getAdvancedSearchedQuotesCount` — separate query pair so basic mode stays byte-identical; price filters compare product + services total; date filters exclude NULLs by construction; all filter params whitelisted/bound.
- Same endpoint `utilities/search_quotes` with `advanced=1` + `statuses[]`/`f_*` params — no new routes.
- Dropdowns server-rendered (active users, `type_of_bids`, `type_of_contracts`); status vocabulary emitted as `window.SQ_STATUSES`; `sq-*` CSS namespace appended to `estilos.css`.
- Chore commit: Playwright now runs via system Chrome with `PW_CHANNEL=chrome` (bundled chromium has no build for this host OS); `@playwright/test` bumped to 1.60.

## Testing

- `tests/php/advanced_search_test.php` — 35 assertions, transaction-isolated (rolls back), covers every filter individually, AND-combinations, union status multi-select, NULL-date exclusion, services-join price semantics, inverted ranges, pagination/ordering.
- `tests/specs/10-advanced-search.spec.js` — 6 Playwright scenarios (basic-mode regression, toggle/panel/invoices-hide, status filter, inverted range empty state, clear filters, toggle-off reset).
- Full regression: 70/70 Playwright E2E, pipeline metrics (47), annual awards (12), charts JS (7) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)