### PR TITLE
fix: cache-bust local CSS/JS includes with asset_url() versioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,8 @@ This is a custom PHP MVC-like application with no framework.
 - `js/` — Per-module JavaScript files (vanilla JS / jQuery)
 - `css/estilos.css` — Single application stylesheet
 
+Local CSS/JS must be included via `asset_url('js/file.js')` (in `routes.inc.php`) — it appends `?v=<filemtime>` so Cloudflare/browser caches drop stale copies after a deploy. Don't use bare `RUTA_CSS`/`RUTA_JS` for assets.
+
 ### Database Access Pattern
 
 All DB access goes through the `Conexion` singleton:

--- a/app/Bootstrap/routes.inc.php
+++ b/app/Bootstrap/routes.inc.php
@@ -242,6 +242,15 @@ define('DOCS', SERVIDOR . 'documentos/');
 define('RUTA_CSS', SERVIDOR . 'css/');
 define('RUTA_JS', SERVIDOR . 'js/');
 define('RUTA_IMG', SERVIDOR . 'img/');
+
+/**
+ * Cache-busted URL for a local asset (path relative to the app root, e.g. 'js/main.js').
+ * Appends ?v=<filemtime> so browser/Cloudflare caches drop stale copies after each deploy.
+ */
+function asset_url($relative_path) {
+  $version = @filemtime(__DIR__ . '/../../' . $relative_path);
+  return SERVIDOR . $relative_path . ($version ? '?v=' . $version : '');
+}
 define('STATES', [
   'AL' => 'Alabama',
   'AK' => 'Alaska',

--- a/plantillas/fulfillment/fulfillment.inc.php
+++ b/plantillas/fulfillment/fulfillment.inc.php
@@ -80,5 +80,5 @@ foreach ($modals as $modal) {
 }
 ?>
 
-<script src="<?= RUTA_JS; ?>fulfillment.js"></script>
-<script src="<?= RUTA_JS; ?>audit_trail.js"></script>
+<script src="<?= asset_url('js/fulfillment.js'); ?>"></script>
+<script src="<?= asset_url('js/audit_trail.js'); ?>"></script>

--- a/plantillas/fulfillment/personnel/personnel.inc.php
+++ b/plantillas/fulfillment/personnel/personnel.inc.php
@@ -40,4 +40,4 @@ include_once 'modals/add_modal.inc.php';
 include_once 'modals/edit_modal.inc.php';
 ?>
 
-<script src="<?= RUTA_JS; ?>personnel.js"></script>
+<script src="<?= asset_url('js/personnel.js'); ?>"></script>

--- a/plantillas/fulfillment/personnel_calendar/personnel_calendar.inc.php
+++ b/plantillas/fulfillment/personnel_calendar/personnel_calendar.inc.php
@@ -32,4 +32,4 @@ include_once 'modals/edit_modal.inc.php';
 include_once 'modals/add_shared_event_modal.inc.php';
 ?>
 
-<script src="<?= RUTA_JS; ?>roadmap.js"></script>
+<script src="<?= asset_url('js/roadmap.js'); ?>"></script>

--- a/plantillas/fulfillment/type_of_project/type_of_project.inc.php
+++ b/plantillas/fulfillment/type_of_project/type_of_project.inc.php
@@ -38,4 +38,4 @@ include_once 'modals/add_modal.inc.php';
 include_once 'modals/edit_modal.inc.php';
 ?>
 
-<script src="<?= RUTA_JS; ?>typeOfProject.js"></script>
+<script src="<?= asset_url('js/typeOfProject.js'); ?>"></script>

--- a/plantillas/kpi/kpi.inc.php
+++ b/plantillas/kpi/kpi.inc.php
@@ -45,4 +45,4 @@
   </section>
 </div>
 
-<script src="<?= RUTA_JS; ?>kpi.js"></script>
+<script src="<?= asset_url('js/kpi.js'); ?>"></script>

--- a/plantillas/payment_terms/payment_terms.inc.php
+++ b/plantillas/payment_terms/payment_terms.inc.php
@@ -36,4 +36,4 @@
 include_once 'modals/add_payment_term_modal.inc.php';
 include_once 'modals/edit_payment_term_modal.inc.php';
 ?>
-<script src="<?= RUTA_JS; ?>payment_terms.js"></script>
+<script src="<?= asset_url('js/payment_terms.js'); ?>"></script>

--- a/plantillas/projection/daily.inc.php
+++ b/plantillas/projection/daily.inc.php
@@ -33,4 +33,4 @@
 
 </div>
 
-<script src="<?= htmlspecialchars(RUTA_JS . 'projections.js') ?>"></script>
+<script src="<?= asset_url('js/projections.js'); ?>"></script>

--- a/plantillas/projection/month.inc.php
+++ b/plantillas/projection/month.inc.php
@@ -103,4 +103,4 @@ Conexion::cerrar_conexion();
 </div>
 
 <?php include_once 'modals/edit_invoice_acceptance.inc.php'; ?>
-<script src="<?= htmlspecialchars(RUTA_JS . 'month.js') ?>"></script>
+<script src="<?= asset_url('js/month.js'); ?>"></script>

--- a/plantillas/projection/monthly.inc.php
+++ b/plantillas/projection/monthly.inc.php
@@ -49,4 +49,4 @@
 </div>
 
 <?php include_once 'modals/edit_monthly_projection.inc.php'; ?>
-<script src="<?= htmlspecialchars(RUTA_JS); ?>monthly.js"></script>
+<script src="<?= asset_url('js/monthly.js'); ?>"></script>

--- a/plantillas/providers/providers.inc.php
+++ b/plantillas/providers/providers.inc.php
@@ -42,4 +42,4 @@ include_once 'modals/add_provider_modal.inc.php';
 include_once 'modals/edit_provider_modal.inc.php';
 ?>
 
-<script src="<?= RUTA_JS; ?>providers.js"></script>
+<script src="<?= asset_url('js/providers.js'); ?>"></script>

--- a/plantillas/quote/editar_cotizacion.inc.php
+++ b/plantillas/quote/editar_cotizacion.inc.php
@@ -149,9 +149,9 @@ include_once 'plantillas/quote/modals/add_provider_subitem_modal.inc.php';
 include_once 'plantillas/quote/modals/edit_provider_subitem_modal.inc.php';
 ?>
 
-<script src="<?= RUTA_JS; ?>services.js"></script>
-<script src="<?= RUTA_JS; ?>quote.js"></script>
-<script src="<?= RUTA_JS; ?>rooms.js"></script>
-<script src="<?= RUTA_JS; ?>audit_trail.js"></script>
-<script src="<?= RUTA_JS; ?>sheet_sync.js"></script>
-<script src="<?= RUTA_JS; ?>sources_sought.js"></script>
+<script src="<?= asset_url('js/services.js'); ?>"></script>
+<script src="<?= asset_url('js/quote.js'); ?>"></script>
+<script src="<?= asset_url('js/rooms.js'); ?>"></script>
+<script src="<?= asset_url('js/audit_trail.js'); ?>"></script>
+<script src="<?= asset_url('js/sheet_sync.js'); ?>"></script>
+<script src="<?= asset_url('js/sources_sought.js'); ?>"></script>

--- a/plantillas/re_quote/re_quote.inc.php
+++ b/plantillas/re_quote/re_quote.inc.php
@@ -89,5 +89,5 @@ include_once 'plantillas/re_quote/modals/audit_trails_modal.inc.php';
 include_once 'modals/edit_service_modal.inc.php';
 ?>
 
-<script src="<?= htmlspecialchars(RUTA_JS); ?>reQuote.js"></script>
-<script src="<?= htmlspecialchars(RUTA_JS); ?>audit_trail.js"></script>
+<script src="<?= asset_url('js/reQuote.js'); ?>"></script>
+<script src="<?= asset_url('js/audit_trail.js'); ?>"></script>

--- a/plantillas/tasks/my_tasks.inc.php
+++ b/plantillas/tasks/my_tasks.inc.php
@@ -19,4 +19,4 @@ include_once 'modals/add_task_modal.inc.php';
 include_once 'modals/edit_task_modal.inc.php';
 ?>
 
-<script src="<?= RUTA_JS; ?>tasks.js"></script>
+<script src="<?= asset_url('js/tasks.js'); ?>"></script>

--- a/plantillas/tasks/tasks.inc.php
+++ b/plantillas/tasks/tasks.inc.php
@@ -19,4 +19,4 @@ include_once 'modals/add_task_modal.inc.php';
 include_once 'modals/edit_task_modal.inc.php';
 ?>
 
-<script src="<?= RUTA_JS; ?>tasks.js"></script>
+<script src="<?= asset_url('js/tasks.js'); ?>"></script>

--- a/plantillas/tasks/tasks_done.inc.php
+++ b/plantillas/tasks/tasks_done.inc.php
@@ -32,4 +32,4 @@
 
 <?php include_once 'modals/edit_task_modal.inc.php'; ?>
 
-<script src="<?= RUTA_JS; ?>tasks.js"></script>
+<script src="<?= asset_url('js/tasks.js'); ?>"></script>

--- a/plantillas/tracking/tracking.inc.php
+++ b/plantillas/tracking/tracking.inc.php
@@ -45,4 +45,4 @@ include_once 'plantillas/tracking/modals/edit_tracking_modal.inc.php';
 include_once 'plantillas/tracking/modals/add_tracking_modal.inc.php';
 include_once 'plantillas/tracking/modals/add_tracking_subitem_modal.inc.php';
 ?>
-<script src="<?= RUTA_JS; ?>tracking.js"></script>
+<script src="<?= asset_url('js/tracking.js'); ?>"></script>

--- a/plantillas/user/edit_user.inc.php
+++ b/plantillas/user/edit_user.inc.php
@@ -34,4 +34,4 @@ try {
 
 </div>
 
-<script src="<?= RUTA_JS; ?>users.js"></script>
+<script src="<?= asset_url('js/users.js'); ?>"></script>

--- a/plantillas/user/registro.inc.php
+++ b/plantillas/user/registro.inc.php
@@ -26,4 +26,4 @@
 
 </div>
 
-<script src="<?= RUTA_JS; ?>users.js"></script>
+<script src="<?= asset_url('js/users.js'); ?>"></script>

--- a/plantillas/user/update_password.inc.php
+++ b/plantillas/user/update_password.inc.php
@@ -42,4 +42,4 @@ try {
 
 </div>
 
-<script src="<?= RUTA_JS; ?>users.js"></script>
+<script src="<?= asset_url('js/users.js'); ?>"></script>

--- a/plantillas/user/users.inc.php
+++ b/plantillas/user/users.inc.php
@@ -39,4 +39,4 @@
 
 </div>
 
-<script src="<?= RUTA_JS; ?>users.js"></script>
+<script src="<?= asset_url('js/users.js'); ?>"></script>

--- a/plantillas/utilities/charts.inc.php
+++ b/plantillas/utilities/charts.inc.php
@@ -61,4 +61,4 @@
 
 </div>
 
-<script src="<?= RUTA_JS ?>main_charts.js"></script>
+<script src="<?= asset_url('js/main_charts.js'); ?>"></script>

--- a/plantillas/utilities/documento_cierre.inc.php
+++ b/plantillas/utilities/documento_cierre.inc.php
@@ -66,11 +66,11 @@
 <script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.19.5/dist/additional-methods.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/admin-lte@3.2/dist/js/adminlte.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-colorpicker/3.4.0/js/bootstrap-colorpicker.min.js" integrity="sha512-94dgCw8xWrVcgkmOc2fwKjO4dqy/X3q7IjFru6MHJKeaAzCvhkVtOS6S+co+RbcZvvPBngLzuVMApmxkuWZGwQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-<script src="<?= RUTA_JS; ?>main.js"></script>
+<script src="<?= asset_url('js/main.js'); ?>"></script>
 <script>
   window.NOTIFICATIONS_USERS_FOR_MENTION_URL = '<?= USERS_FOR_MENTION ?>';
 </script>
-<script src="<?= RUTA_JS; ?>mentions.js"></script>
+<script src="<?= asset_url('js/mentions.js'); ?>"></script>
 </body>
 
 </html>

--- a/plantillas/utilities/documento_declaracion.inc.php
+++ b/plantillas/utilities/documento_declaracion.inc.php
@@ -33,7 +33,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ttskch/select2-bootstrap4-theme@x.x.x/dist/select2-bootstrap4.min.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-colorpicker/3.4.0/css/bootstrap-colorpicker.css" integrity="sha512-HcfKB3Y0Dvf+k1XOwAD6d0LXRFpCnwsapllBQIvvLtO2KMTa0nI5MtuTv3DuawpsiA0ztTeu690DnMux/SuXJQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css">
-  <link rel="stylesheet" href="<?= RUTA_CSS; ?>estilos.css">
+  <link rel="stylesheet" href="<?= asset_url('css/estilos.css'); ?>">
 </head>
 
 <body class="hold-transition sidebar-mini sidebar-collapse layout-fixed layout-navbar-fixed">

--- a/plantillas/utilities/employee_docs_page.inc.php
+++ b/plantillas/utilities/employee_docs_page.inc.php
@@ -90,4 +90,4 @@
 
 <?php include_once 'modals/add_employee_doc_modal.inc.php'; ?>
 
-<script src="<?= RUTA_JS; ?>employee_docs.js"></script>
+<script src="<?= asset_url('js/employee_docs.js'); ?>"></script>

--- a/plantillas/utilities/pipeline_metrics.inc.php
+++ b/plantillas/utilities/pipeline_metrics.inc.php
@@ -172,4 +172,4 @@ $pm_current_year = (int)date('Y');
   };
 </script>
 <script src="https://cdn.jsdelivr.net/npm/apexcharts@3.49.1/dist/apexcharts.min.js"></script>
-<script src="<?= RUTA_JS; ?>pipeline_metrics.js"></script>
+<script src="<?= asset_url('js/pipeline_metrics.js'); ?>"></script>

--- a/plantillas/utilities/reports_charts.inc.php
+++ b/plantillas/utilities/reports_charts.inc.php
@@ -77,5 +77,5 @@
 </div>
 
 <!-- External Scripts -->
-<script src="<?= RUTA_JS; ?>reports.js"></script>
-<script src="<?= RUTA_JS; ?>reports_charts.js"></script>
+<script src="<?= asset_url('js/reports.js'); ?>"></script>
+<script src="<?= asset_url('js/reports_charts.js'); ?>"></script>

--- a/plantillas/utilities/reports_tables.inc.php
+++ b/plantillas/utilities/reports_tables.inc.php
@@ -151,4 +151,4 @@ document.querySelector('span[data="generate_report"]').addEventListener('click',
 });
 </script>
 
-<script src="<?= RUTA_JS; ?>reports.js"></script>
+<script src="<?= asset_url('js/reports.js'); ?>"></script>

--- a/plantillas/utilities/search_quotes.inc.php
+++ b/plantillas/utilities/search_quotes.inc.php
@@ -231,4 +231,4 @@ $sq_statuses = array_map(function ($s) use ($sq_label_overrides) {
 <script>
   window.SQ_STATUSES = <?= json_encode($sq_statuses); ?>;
 </script>
-<script src="<?= RUTA_JS; ?>searchQuotes.js"></script>
+<script src="<?= asset_url('js/searchQuotes.js'); ?>"></script>

--- a/vistas/404.php
+++ b/vistas/404.php
@@ -10,7 +10,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:opsz@6..12&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.5.0/css/all.css" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/admin-lte@3.2/dist/css/adminlte.min.css">
-  <link rel="stylesheet" href="<?= RUTA_CSS; ?>estilos.css">
+  <link rel="stylesheet" href="<?= asset_url('css/estilos.css'); ?>">
 </head>
 
 <body>


### PR DESCRIPTION
## Summary

Prod is behind Cloudflare with `cache-control: max-age=14400`, so every deploy could serve stale `estilos.css` / per-page JS for up to 4 hours at the edge plus 4 more in browsers — exactly what broke the Advanced Quote Search rollout (new HTML rendered with the old stylesheet and old `searchQuotes.js`).

- New `asset_url($relative_path)` helper in `app/Bootstrap/routes.inc.php`: returns `SERVIDOR . path . '?v=' . filemtime(file)`, falling back to the bare URL if the file is missing.
- All 38 local asset includes across `plantillas/` and `vistas/` (30 files) rewritten from `<?= RUTA_JS; ?>x.js` (and the `htmlspecialchars` variants) to `<?= asset_url('js/x.js'); ?>`.
- CDN-hosted libraries are untouched; `RUTA_CSS`/`RUTA_JS` constants remain for any non-asset use.
- CLAUDE.md notes the convention for future includes.

Since `filemtime` changes whenever a deploy updates a file, each release produces new URLs (`estilos.css?v=1781120014`) and both Cloudflare and browsers fetch fresh copies automatically — no more manual purges.

## Testing

- Verified rendered pages emit versioned URLs locally.
- Helper degrades gracefully for missing files (no `?v=`).
- Full Playwright suite: 70/70 pass (one pipeline-metrics flake passed on rerun).

🤖 Generated with [Claude Code](https://claude.com/claude-code)