### PR TITLE
fix: add total price column to partial invoices search results table

### DIFF
--- a/app/Quote/RepositorioRfq.inc.php
+++ b/app/Quote/RepositorioRfq.inc.php
@@ -2043,6 +2043,7 @@ class RepositorioRfq {
       case 1: $sort_column = 'inv.created_at'; break;
       case 2: $sort_column = 'r.email_code'; break;
       case 3: $sort_column = 'u.nombre_usuario'; break;
+      case 4: $sort_column = 'total_price'; break;
       default: $sort_column = 'inv.created_at'; break;
     }
     if (isset($conexion)) {
@@ -2053,12 +2054,15 @@ class RepositorioRfq {
           DATE_FORMAT(inv.created_at, '%m/%d/%Y') AS invoice_date,
           r.id AS quote_id,
           r.email_code,
-          u.nombre_usuario
+          u.nombre_usuario,
+          COALESCE(SUM(COALESCE(s.total_price, 0)) + COALESCE(r.total_price, 0), 0) AS total_price
         FROM invoices inv
         JOIN rfq r ON inv.id_rfq = r.id
         LEFT JOIN usuarios u ON r.usuario_designado = u.id
+        LEFT JOIN services s ON r.id = s.id_rfq
         WHERE r.deleted = 0
           AND inv.name LIKE :search_term
+        GROUP BY inv.id, inv.name, inv.created_at, r.id, r.email_code, u.nombre_usuario, r.total_price
         ORDER BY {$sort_column} {$sort_direction}
         LIMIT {$start}, {$length}
         ";

--- a/js/searchQuotes.js
+++ b/js/searchQuotes.js
@@ -147,6 +147,7 @@ $(document).ready(function () {
           },
         },
         { data: 'nombre_usuario' },
+        { data: 'total_price' },
       ],
       createdRow: function (row) {
         $(row).addClass('table-info');

--- a/plantillas/utilities/search_quotes.inc.php
+++ b/plantillas/utilities/search_quotes.inc.php
@@ -217,6 +217,7 @@ $sq_statuses = array_map(function ($s) use ($sq_label_overrides) {
                 <th>Invoice Date</th>
                 <th>Parent Quote</th>
                 <th>Designated User</th>
+                <th>Total Price</th>
               </tr>
             </thead>
             <tbody></tbody>


### PR DESCRIPTION
## Summary
- Adds a **Total Price** column to the Partial Invoices table in the Search Quotes default mode
- Value is computed as product total + services subtotal, matching the formula used in the main Quotes table
- Supports sorting by total price (column index 4)

## Changes
- `app/Quote/RepositorioRfq.inc.php` — `getSearchedInvoices`: joins `services`, computes `total_price`, adds `GROUP BY`, adds sort case 4
- `plantillas/utilities/search_quotes.inc.php` — adds `<th>Total Price</th>` to the invoices table header
- `js/searchQuotes.js` — adds `{ data: 'total_price' }` column to `initializeInvoicesTable`

## Test plan
- [ ] Search for a keyword that returns partial invoices in default mode
- [ ] Confirm the Total Price column appears and shows the correct value matching the parent quote's total

🤖 Generated with [Claude Code](https://claude.com/claude-code)