### PR TITLE
feat: add 50/50 payment term for commercial moving quotes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 | Quote Lifecycle Audit Events (audit-trail entries on quote create / sync / unsync, surfaced via the Audit Trail modal's Sync tab) | built | — |
 | Write-Once Sheet Sync (app creates a sheet row if missing but never overwrites/deletes an existing one — sync becomes create-or-link) | built | — |
 | Advanced Quote Search (Advanced toggle + filter panel on Search Quotes, Status pill column) | built | — |
+| Commercial Moving bid type + 50/50 payment term (new bid type; "50% Upfront / 50% on Completion" term, split shown on quote + PDF, no calc change) | built | — |
 
 ## Environment
 
@@ -198,3 +199,12 @@ Search Quotes (`perfil/search_quotes`) has an **Advanced** toggle beside the key
 - **Backend:** `RepositorioRfq::getAdvancedSearchedQuotes` / `getAdvancedSearchedQuotesCount` — a separate pair so the basic-mode queries stay untouched. Derived status reuses `PipelineMetricsRepository::STATUS_CASE` verbatim (filter counts match the pipeline chart); price filters compare product + services total; date filters exclude NULLs by construction. Same endpoint `utilities/search_quotes` with `advanced=1` + `statuses[]`/`f_*` params (whitelisted in `advancedSearchWhere`).
 - **Frontend:** dropdowns server-rendered in `search_quotes.inc.php` (active users, `type_of_bids`, `type_of_contracts`); status vocabulary emitted as `window.SQ_STATUSES` (keys/colors from `PipelineMetricsRepository::STATUSES`, labels per design). `js/searchQuotes.js` swaps DataTable column sets (inserts/removes the Status `<th>`) when toggling modes. `sq-*` CSS namespace at the bottom of `estilos.css`.
 - **Tests:** `tests/php/advanced_search_test.php` (35 assertions, transaction-isolated, client-marker scoping); `tests/specs/10-advanced-search.spec.js` (Playwright). Playwright on hosts without a bundled-chromium build: run with `PW_CHANNEL=chrome` to use system Google Chrome.
+
+### Commercial Moving + 50/50 Payment Term
+
+New bid type "Commercial Moving" (`sql/commercial_moving_payment_term_migration.sql`, idempotent, local + prod) + a third payment term **`50% Upfront / 50% on Completion`** — the canonical string stored in `rfq.payment_terms`/`rfq.services_payment_term` (**no schema change**; split computed on the fly). Bid type is **not** in `nueva_cotizacion.inc.php`'s `SYNCABLE_BID_TYPES`, so "Sync to pipeline" auto-defaults **off**; it surfaces in the metrics category breakdown automatically (grouped by `type_of_bid`).
+
+- **No calc change:** 50/50 is a schedule, ×1 like Net 30. Every calc/PDF path already special-cased only `Net 30/CC` (×1.03 services, ×1.0298661174047374 items), so non-CC terms were already ×1.
+- **Controls:** items + services payment-term **radios → 3-option `<select class="js-payment-terms">`** (`RepositorioItem`/`ServiceRepository`; re-quote `ReQuoteItemRepository`/`ReQuoteServiceRepository`). Quote-wide **all-or-nothing** mirroring in `js/quote.js` + `js/reQuote.js`: 50/50 on either sets both; leaving it resets the other to Net 30; Net 30 / Net 30/CC stay independent.
+- **Split display:** `js/payment_split.js` (`split5050` + `PAYMENT_TERM_SPLIT`, Node-requireable + `window`; loaded before quote/reQuote.js; odd cents → upfront). App: bottom bar `#payment_split_totals` shown only when split (`renderPaymentSplit`). PDF: `proposal.inc.php` adds two rows under TOTAL + completion note via `ProposalRepository::is_split_term`/`split_5050`. Re-quote PDF (internal cost sheet) + `proposal_room.inc.php` intentionally get no split block.
+- **Tests:** `tests/js/payment_split.test.js`; `tests/php/commercial_moving_test.php` (self-cleaning).

--- a/app/Quote/RepositorioItem.inc.php
+++ b/app/Quote/RepositorioItem.inc.php
@@ -287,17 +287,13 @@ class RepositorioItem {
           </div>
           <div class="col-md-3">
             <label>Payment Terms</label>
-            <div class="d-flex gap-3" style="gap:16px;">
-              <div class="custom-control custom-radio">
-                <input type="radio" id="net_30" name="payment_terms" class="custom-control-input" value="Net 30" <?php echo $cotizacion->obtener_payment_terms() == 'Net 30' ? 'checked' : ''; ?>>
-                <label class="custom-control-label" for="net_30">Net 30</label>
-              </div>
-              <div class="custom-control custom-radio">
-                <input type="radio" id="net_30cc" name="payment_terms" class="custom-control-input" value="Net 30/CC" <?php echo $cotizacion->obtener_payment_terms() == 'Net 30/CC' ? 'checked' : ''; ?>>
-                <label class="custom-control-label" for="net_30cc">Net 30/CC</label>
-              </div>
-            </div>
-            <input type="hidden" name="payment_terms_original" value="<?php echo $cotizacion->obtener_payment_terms(); ?>">
+            <?php $items_payment_terms = $cotizacion->obtener_payment_terms(); ?>
+            <select name="payment_terms" id="items_payment_terms" class="form-control form-control-sm js-payment-terms">
+              <option value="Net 30" <?= $items_payment_terms == 'Net 30' ? 'selected' : ''; ?>>Net 30</option>
+              <option value="Net 30/CC" <?= $items_payment_terms == 'Net 30/CC' ? 'selected' : ''; ?>>Net 30/CC</option>
+              <option value="50% Upfront / 50% on Completion" <?= $items_payment_terms == '50% Upfront / 50% on Completion' ? 'selected' : ''; ?>>50% Upfront / 50% on Completion</option>
+            </select>
+            <input type="hidden" name="payment_terms_original" value="<?= htmlspecialchars($items_payment_terms); ?>">
           </div>
         </div>
       </div>

--- a/app/ReQuote/ReQuoteItemRepository.inc.php
+++ b/app/ReQuote/ReQuoteItemRepository.inc.php
@@ -53,16 +53,15 @@ class ReQuoteItemRepository {
         <i class="fas fa-list mr-1"></i> Items
       </span>
       <div style="display:flex;align-items:center;gap:16px;">
-        <div style="display:flex;align-items:center;gap:12px;font-size:13px;">
-          <div class="custom-control custom-radio custom-control-inline">
-            <input type="radio" id="net_30" name="payment_terms" class="custom-control-input" value="Net 30" <?= $re_quote->get_payment_terms() == 'Net 30' ? 'checked' : ''; ?>>
-            <label class="custom-control-label" for="net_30">Net 30</label>
-          </div>
-          <div class="custom-control custom-radio custom-control-inline">
-            <input type="radio" id="net_30_cc" name="payment_terms" class="custom-control-input" value="Net 30/CC" <?= $re_quote->get_payment_terms() == 'Net 30/CC' ? 'checked' : ''; ?>>
-            <label class="custom-control-label" for="net_30_cc">Net 30/CC</label>
-          </div>
-          <input type="hidden" name="payment_terms_original" value="<?= $re_quote->get_payment_terms(); ?>">
+        <div style="display:flex;align-items:center;gap:8px;font-size:13px;">
+          <span style="font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.4px;color:#8896a5;">Payment Terms</span>
+          <?php $rq_payment_terms = $re_quote->get_payment_terms(); ?>
+          <select name="payment_terms" id="rq_items_payment_terms" class="form-control form-control-sm js-payment-terms" style="width:auto;">
+            <option value="Net 30" <?= $rq_payment_terms == 'Net 30' ? 'selected' : ''; ?>>Net 30</option>
+            <option value="Net 30/CC" <?= $rq_payment_terms == 'Net 30/CC' ? 'selected' : ''; ?>>Net 30/CC</option>
+            <option value="50% Upfront / 50% on Completion" <?= $rq_payment_terms == '50% Upfront / 50% on Completion' ? 'selected' : ''; ?>>50% Upfront / 50% on Completion</option>
+          </select>
+          <input type="hidden" name="payment_terms_original" value="<?= htmlspecialchars($rq_payment_terms); ?>">
         </div>
         <a target="_blank" href="<?= PDF_RE_QUOTE . $re_quote->get_id_rfq(); ?>" class="btn btn-outline-secondary btn-sm">
           <i class="fa fa-file mr-1"></i> PDF

--- a/app/ReQuote/ReQuoteServiceRepository.inc.php
+++ b/app/ReQuote/ReQuoteServiceRepository.inc.php
@@ -28,16 +28,14 @@ class ReQuoteServiceRepository {
     <?php return; endif; ?>
 
     <!-- Payment terms -->
-    <div style="display:flex;align-items:center;gap:16px;margin-bottom:12px;font-size:13px;">
+    <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px;font-size:13px;">
       <span style="font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.4px;color:#8896a5;">Payment Terms</span>
-      <div class="custom-control custom-radio custom-control-inline">
-        <input type="radio" id="net_30Services" name="services_payment_term" class="custom-control-input" value="Net 30" <?= $re_quote->get_services_payment_term() == 'Net 30' ? 'checked' : ''; ?>>
-        <label class="custom-control-label" for="net_30Services">Net 30</label>
-      </div>
-      <div class="custom-control custom-radio custom-control-inline">
-        <input type="radio" id="net_30ccServices" name="services_payment_term" class="custom-control-input" value="Net 30/CC" <?= $re_quote->get_services_payment_term() == 'Net 30/CC' ? 'checked' : ''; ?>>
-        <label class="custom-control-label" for="net_30ccServices">Net 30/CC</label>
-      </div>
+      <?php $rq_services_payment_term = $re_quote->get_services_payment_term(); ?>
+      <select name="services_payment_term" id="rq_services_payment_term" class="form-control form-control-sm js-payment-terms" style="width:auto;">
+        <option value="Net 30" <?= $rq_services_payment_term == 'Net 30' ? 'selected' : ''; ?>>Net 30</option>
+        <option value="Net 30/CC" <?= $rq_services_payment_term == 'Net 30/CC' ? 'selected' : ''; ?>>Net 30/CC</option>
+        <option value="50% Upfront / 50% on Completion" <?= $rq_services_payment_term == '50% Upfront / 50% on Completion' ? 'selected' : ''; ?>>50% Upfront / 50% on Completion</option>
+      </select>
     </div>
 
     <!-- Services table -->

--- a/app/Service/ServiceRepository.inc.php
+++ b/app/Service/ServiceRepository.inc.php
@@ -86,16 +86,12 @@ class ServiceRepository {
         <div class="row">
           <div class="col-md-4">
             <label>Payment Terms</label>
-            <div class="d-flex" style="gap:16px;">
-              <div class="custom-control custom-radio">
-                <input type="radio" id="net_30Services" name="services_payment_term" class="custom-control-input" value="Net 30" <?= $quote->obtener_services_payment_term() == 'Net 30' ? 'checked' : ''; ?>>
-                <label class="custom-control-label" for="net_30Services">Net 30</label>
-              </div>
-              <div class="custom-control custom-radio">
-                <input type="radio" id="net_30ccServices" name="services_payment_term" class="custom-control-input" value="Net 30/CC" <?= $quote->obtener_services_payment_term() == 'Net 30/CC' ? 'checked' : ''; ?>>
-                <label class="custom-control-label" for="net_30ccServices">Net 30/CC</label>
-              </div>
-            </div>
+            <?php $services_payment_term = $quote->obtener_services_payment_term(); ?>
+            <select name="services_payment_term" id="services_payment_term" class="form-control form-control-sm js-payment-terms">
+              <option value="Net 30" <?= $services_payment_term == 'Net 30' ? 'selected' : ''; ?>>Net 30</option>
+              <option value="Net 30/CC" <?= $services_payment_term == 'Net 30/CC' ? 'selected' : ''; ?>>Net 30/CC</option>
+              <option value="50% Upfront / 50% on Completion" <?= $services_payment_term == '50% Upfront / 50% on Completion' ? 'selected' : ''; ?>>50% Upfront / 50% on Completion</option>
+            </select>
           </div>
         </div>
       </div>

--- a/app/Utilities/ProposalRepository.inc.php
+++ b/app/Utilities/ProposalRepository.inc.php
@@ -1,5 +1,21 @@
 <?php
 class ProposalRepository{
+  // Canonical value stored in rfq.payment_terms / rfq.services_payment_term for the
+  // "50% Upfront / 50% on Completion" term. No calc change — it is a payment schedule.
+  const PAYMENT_TERM_SPLIT = '50% Upfront / 50% on Completion';
+
+  public static function is_split_term($term){
+    return $term === self::PAYMENT_TERM_SPLIT;
+  }
+
+  /* Half the total, always summing back to the exact total. Odd cents go to the
+     upfront half so the pair reconciles cleanly (8749.55 -> 4374.78 + 4374.77). */
+  public static function split_5050($total){
+    $cents = (int) round(((float) $total) * 100);
+    $up = (int) ceil($cents / 2);
+    return ['upfront' => $up / 100, 'completion' => ($cents - $up) / 100];
+  }
+
   public static function print_item($item, $limit, $a){
     $item_description = '';
     $html = '';

--- a/css/estilos.css
+++ b/css/estilos.css
@@ -1653,6 +1653,28 @@ h3.text-info.text-center .fa-exclamation-circle {
   color: var(--color-dark);
   line-height: 1.2;
 }
+/* 50/50 payment split — read-only, visually secondary to the grand total */
+.quote-split {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  animation: quoteSplitIn 0.2s ease;
+}
+@keyframes quoteSplitIn {
+  from { opacity: 0; transform: translateX(6px); }
+  to   { opacity: 1; transform: none; }
+}
+.quote-split-total .quote-action-total__value.quote-split-value {
+  font-size: 14px;
+  font-weight: 600;
+  color: #5a6a7e;
+}
+.quote-split-pct {
+  font-size: 9px;
+  font-weight: 700;
+  color: #aab4c2;
+  margin-left: 3px;
+}
 
 /* =============================================
    ADD ITEM — Comparison panel layout

--- a/forms/quote/edicion_cotizacion_recuperada.inc.php
+++ b/forms/quote/edicion_cotizacion_recuperada.inc.php
@@ -139,6 +139,17 @@
   </div>
 
   <div class="quote-action-bar__totals">
+    <!-- 50/50 split — shown only when the "50% Upfront / 50% on Completion" term is active (quote.js) -->
+    <div class="quote-split" id="payment_split_totals" style="display:none;">
+      <div class="quote-action-total quote-split-total">
+        <span class="quote-action-total__label">Due Upfront <span class="quote-split-pct">50%</span></span>
+        <span class="quote-action-total__value quote-split-value" id="bar-due-upfront">$0.00</span>
+      </div>
+      <div class="quote-action-total quote-split-total">
+        <span class="quote-action-total__label">Due on Completion <span class="quote-split-pct">50%</span></span>
+        <span class="quote-action-total__value quote-split-value" id="bar-due-completion">$0.00</span>
+      </div>
+    </div>
     <div class="quote-action-total">
       <span class="quote-action-total__label">Total Price</span>
       <span class="quote-action-total__value" id="bar-total-price">$<?= number_format($cotizacion_recuperada->obtener_quote_total_price(), 2); ?></span>

--- a/herramientas/pdfTemplates/proposal.inc.php
+++ b/herramientas/pdfTemplates/proposal.inc.php
@@ -142,6 +142,17 @@
       padding: 10px;
     }
 
+    /* ── 50/50 split rows (below TOTAL, read-only, secondary) ── */
+    .items-table .split-row td {
+      background: #fff !important;
+      border: none;
+      border-bottom: 1px solid #e5edf5;
+      font-size: 9pt;
+      font-weight: 600;
+      color: #1e5aa8;
+      padding: 6px 10px;
+    }
+
     .num-col   { width: 22px; text-align: center; }
     .qty-col   { width: 30px; text-align: center; }
     .price-col { width: 100px; text-align: right; }
@@ -229,7 +240,7 @@
       </td>
       <td>
         <div class="d-label">Payment Terms</div>
-        <div class="d-value"><?= htmlspecialchars($payment_terms) ?></div>
+        <div class="d-value"<?= ProposalRepository::is_split_term($payment_terms) ? ' style="color:#1e5aa8;"' : '' ?>><?= htmlspecialchars($payment_terms) ?></div>
       </td>
     </tr>
   </table>
@@ -284,15 +295,35 @@
         <td class="total-col">$ <?= number_format($cotizacion->obtener_shipping_cost(), 2) ?></td>
       </tr>
 
+      <?php
+      $grand_total = $cotizacion->obtener_total_price() + $total_service;
+      $is_split = ProposalRepository::is_split_term($payment_terms);
+      ?>
       <tr class="total-row">
         <td colspan="3" style="text-align:right;">TOTAL</td>
-        <td colspan="2" style="text-align:right;">$ <?= number_format($cotizacion->obtener_total_price() + $total_service, 2) ?></td>
+        <td colspan="2" style="text-align:right;">$ <?= number_format($grand_total, 2) ?></td>
       </tr>
+
+      <?php if ($is_split) : $split = ProposalRepository::split_5050($grand_total); ?>
+        <tr class="split-row">
+          <td colspan="3" style="text-align:right;">Due Upfront <span style="color:#8fa8c4;">(50%)</span></td>
+          <td colspan="2" style="text-align:right;">$ <?= number_format($split['upfront'], 2) ?></td>
+        </tr>
+        <tr class="split-row">
+          <td colspan="3" style="text-align:right;">Due on Completion <span style="color:#8fa8c4;">(50%)</span></td>
+          <td colspan="2" style="text-align:right;">$ <?= number_format($split['completion'], 2) ?></td>
+        </tr>
+      <?php endif; ?>
 
     </tbody>
   </table>
 
-  <?php if ($payment_terms === 'Net 30') : ?>
+  <?php if ($is_split) : ?>
+    <div class="payment-note">
+      <b>50% due upon acceptance, 50% due upon completion of the move.</b>
+      An invoice for the upfront half is issued at contract award; the balance is invoiced on final delivery and sign-off.
+    </div>
+  <?php elseif ($payment_terms === 'Net 30') : ?>
     <div class="payment-note">
       <b>Payment Terms</b>
       Net Terms: 30 Days &nbsp;·&nbsp;

--- a/js/payment_split.js
+++ b/js/payment_split.js
@@ -1,0 +1,24 @@
+/* Payment Terms — "50% Upfront / 50% on Completion"
+   Shared helper for the quote + re-quote pages. Pure logic (no DOM) so it can be
+   unit-tested under Node (tests/js/payment_split.test.js) and reused in the
+   browser via the window globals. */
+
+// Canonical string stored in rfq.payment_terms / rfq.services_payment_term.
+var PAYMENT_TERM_SPLIT = '50% Upfront / 50% on Completion';
+
+/* Half the total, always summing back to the exact total. Odd cents go to the
+   upfront half so the pair reconciles cleanly (8749.55 -> 4374.78 + 4374.77). */
+function split5050(total) {
+  var cents = Math.round((Number(total) || 0) * 100);
+  var up = Math.ceil(cents / 2);
+  return { upfront: up / 100, completion: (cents - up) / 100 };
+}
+
+if (typeof window !== 'undefined') {
+  window.PAYMENT_TERM_SPLIT = PAYMENT_TERM_SPLIT;
+  window.split5050 = split5050;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { PAYMENT_TERM_SPLIT, split5050 };
+}

--- a/js/quote.js
+++ b/js/quote.js
@@ -20,8 +20,27 @@ $(document).ready(function () {
 
   const totalQuantity = quantity.reduce((sum, qty) => sum + qty, 0);
 
+  const SPLIT_TERM = window.PAYMENT_TERM_SPLIT || '50% Upfront / 50% on Completion';
+
+  // The 50/50 split term is a payment schedule, not a price change — it uses the
+  // same ×1 multiplier as Net 30. Only Net 30/CC applies an uplift.
+  function paymentTermIsSplit() {
+    return $('[name="payment_terms"]').val() === SPLIT_TERM
+      || $('[name="services_payment_term"]').val() === SPLIT_TERM;
+  }
+
+  function renderPaymentSplit(total) {
+    const $wrap = $('#payment_split_totals');
+    if (!$wrap.length) return;
+    if (!paymentTermIsSplit()) { $wrap.hide(); return; }
+    const s = window.split5050(total);
+    $('#bar-due-upfront').text(`$${s.upfront.toFixed(2)}`);
+    $('#bar-due-completion').text(`$${s.completion.toFixed(2)}`);
+    $wrap.css('display', 'flex');
+  }
+
   const calcQuoteTable = () => {
-    const paymentTerms = $('input:radio[name=payment_terms]:checked').val() === 'Net 30/CC'
+    const paymentTerms = $('[name="payment_terms"]').val() === 'Net 30/CC'
       ? 1.0298661174047374
       : 1;
     const taxesMultiplier = (parseFloat($('#taxes').val()) / 100 || 0) + 1;
@@ -105,7 +124,7 @@ $(document).ready(function () {
     $('#total_additional').html(`$ ${totalAdditional.toFixed(2)}`);
 
     // Services calculation — runs in the same tick so the total feeds into the bottom bar
-    const svcPaymentMultiplier = $('input:radio[name=services_payment_term]:checked').val() === 'Net 30/CC' ? 1.03 : 1;
+    const svcPaymentMultiplier = $('[name="services_payment_term"]').val() === 'Net 30/CC' ? 1.03 : 1;
     let totalServices = 0;
     $('#services_table tbody .service_item').each(function () {
       const $cells = $(this).find('td');
@@ -126,7 +145,24 @@ $(document).ready(function () {
     $('#bar-total-price').text(`$${totalPrice.toFixed(2)}`);
     $('#bar-total-profit').text(`$${profit}`);
     $('#bar-profit-pct').text(`${percentageProfit}%`);
+
+    // 50/50 split — Due Upfront / Due on Completion beside the grand total
+    renderPaymentSplit(totalPrice);
   };
+
+  // 50/50 is one arrangement for the whole job: selecting it on either table mirrors
+  // to the other; leaving it resets the other table to Net 30. Net 30 / Net 30/CC
+  // stay independently selectable per table.
+  $('#form_edited_quote').on('change', 'select.js-payment-terms', function () {
+    const $changed = $(this);
+    const $other = $('select.js-payment-terms').not($changed);
+    if (!$other.length) return;
+    if ($changed.val() === SPLIT_TERM) {
+      if ($other.val() !== SPLIT_TERM) $other.val(SPLIT_TERM).trigger('change');
+    } else if ($other.val() === SPLIT_TERM) {
+      $other.val('Net 30').trigger('change');
+    }
+  });
 
   // Set interval for dynamic updates and trigger on form submission
   if ($('#form_edited_quote').length) {
@@ -146,7 +182,7 @@ $(document).ready(function () {
       $('input[name="taxes_original"]').val($('[name="taxes"]').val());
       $('input[name="profit_original"]').val($('[name="profit"]').val());
       $('input[name="additional_general_original"]').val($('[name="additional_general"]').val());
-      $('input[name="payment_terms_original"]').val($('input[name="payment_terms"]:checked').val());
+      $('input[name="payment_terms_original"]').val($('[name="payment_terms"]').val());
       $('input[name="shipping_original"]').val($('[name="shipping"]').val());
       $('input[name="shipping_cost_original"]').val($('[name="shipping_cost"]').val());
     }
@@ -185,7 +221,7 @@ $(document).ready(function () {
     );
     $('#form_edited_quote').on(
       'change',
-      'input[name="payment_terms"], input[name="services_payment_term"]',
+      '[name="payment_terms"], [name="services_payment_term"]',
       scheduleAutosave
     );
     $('#form_edited_quote').on('input blur', '#shipping', scheduleAutosave);

--- a/js/reQuote.js
+++ b/js/reQuote.js
@@ -3,7 +3,7 @@ $(document).ready(function () {
   if ($('#requote_table').length !== 0) {
     const calculateTotals = () => {
       const totalGanado = parseFloat($('#total_ganado').html().split(' ')[1]);
-      const paymentTermsMultiplier = $('input:radio[name=payment_terms]:checked').val() === 'Net 30/CC' ? 0.029 : 0;
+      const paymentTermsMultiplier = $('[name=payment_terms]').val() === 'Net 30/CC' ? 0.029 : 0;
       const paymentTerms = totalGanado * paymentTermsMultiplier;
 
       const totales = $('#re_quote_data tr').map((_, row) => {
@@ -67,7 +67,7 @@ $(document).ready(function () {
 
   // Calculate service totals
   const calcServices = () => {
-    const paymentTermsMultiplier = $('input:radio[name=services_payment_term]:checked').val() === 'Net 30/CC' ? 1.0299 : 1;
+    const paymentTermsMultiplier = $('[name=services_payment_term]').val() === 'Net 30/CC' ? 1.0299 : 1;
     let totalServices = 0;
 
     $('#services_table tbody .service_item').each(function (i) {
@@ -89,6 +89,22 @@ $(document).ready(function () {
 
   // Recalculate totals before submitting the form
   $('#form_edited_quote').submit(calcServices);
+
+  /****************************PAYMENT TERMS 50/50 MIRRORING*******************************************/
+  // 50/50 is one arrangement for the whole job: selecting it on either table mirrors
+  // to the other; leaving it resets the other table to Net 30. Net 30 / Net 30/CC
+  // stay independently selectable per table.
+  const SPLIT_TERM = window.PAYMENT_TERM_SPLIT || '50% Upfront / 50% on Completion';
+  $(document).on('change', 'select.js-payment-terms', function () {
+    const $changed = $(this);
+    const $other = $('select.js-payment-terms').not($changed);
+    if (!$other.length) return;
+    if ($changed.val() === SPLIT_TERM) {
+      if ($other.val() !== SPLIT_TERM) $other.val(SPLIT_TERM).trigger('change');
+    } else if ($other.val() === SPLIT_TERM) {
+      $other.val('Net 30').trigger('change');
+    }
+  });
 
   // Edit service modal logic
   $('#services_table').on('click', '.edit_service', function () {

--- a/plantillas/quote/editar_cotizacion.inc.php
+++ b/plantillas/quote/editar_cotizacion.inc.php
@@ -150,6 +150,7 @@ include_once 'plantillas/quote/modals/edit_provider_subitem_modal.inc.php';
 ?>
 
 <script src="<?= asset_url('js/services.js'); ?>"></script>
+<script src="<?= asset_url('js/payment_split.js'); ?>"></script>
 <script src="<?= asset_url('js/quote.js'); ?>"></script>
 <script src="<?= asset_url('js/rooms.js'); ?>"></script>
 <script src="<?= asset_url('js/audit_trail.js'); ?>"></script>

--- a/plantillas/re_quote/re_quote.inc.php
+++ b/plantillas/re_quote/re_quote.inc.php
@@ -89,5 +89,6 @@ include_once 'plantillas/re_quote/modals/audit_trails_modal.inc.php';
 include_once 'modals/edit_service_modal.inc.php';
 ?>
 
+<script src="<?= asset_url('js/payment_split.js'); ?>"></script>
 <script src="<?= asset_url('js/reQuote.js'); ?>"></script>
 <script src="<?= asset_url('js/audit_trail.js'); ?>"></script>

--- a/sql/commercial_moving_payment_term_migration.sql
+++ b/sql/commercial_moving_payment_term_migration.sql
@@ -1,0 +1,12 @@
+-- Commercial Moving bid type + 50/50 payment term
+--
+-- Adds the "Commercial Moving" bid type so it appears in the quote bid-type
+-- dropdown and the pipeline metrics category breakdown. Idempotent — safe to
+-- re-run on local + prod.
+--
+-- The "50% Upfront / 50% on Completion" payment term needs NO schema change:
+-- it is stored as the existing string value in rfq.payment_terms /
+-- rfq.services_payment_term, and the split amounts are computed on the fly.
+INSERT INTO type_of_bids (type_of_bid)
+SELECT 'Commercial Moving'
+WHERE 'Commercial Moving' NOT IN (SELECT type_of_bid FROM type_of_bids);

--- a/tests/js/payment_split.test.js
+++ b/tests/js/payment_split.test.js
@@ -1,0 +1,49 @@
+/* Unit tests for the 50/50 payment-split helper (feature: commercial-moving-payment-term).
+   Run with: node --test tests/js/
+   Exercises split5050() from js/payment_split.js — the pure helper that halves the
+   grand total for the "50% Upfront / 50% on Completion" term. The two halves must
+   always sum back to the exact total; odd cents go to the upfront half. */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { split5050, PAYMENT_TERM_SPLIT } = require('../../js/payment_split.js');
+
+test('clean total splits into two equal halves', () => {
+  const { upfront, completion } = split5050(25000);
+  assert.equal(upfront, 12500);
+  assert.equal(completion, 12500);
+});
+
+test('odd-cent total reconciles to the exact total (extra cent to upfront)', () => {
+  const { upfront, completion } = split5050(8749.55);
+  assert.equal(upfront, 4374.78);
+  assert.equal(completion, 4374.77);
+  assert.equal(Math.round((upfront + completion) * 100), Math.round(8749.55 * 100));
+});
+
+test('zero total splits into $0.00 / $0.00', () => {
+  const { upfront, completion } = split5050(0);
+  assert.equal(upfront, 0);
+  assert.equal(completion, 0);
+});
+
+test('non-numeric / undefined total is treated as zero', () => {
+  const { upfront, completion } = split5050(undefined);
+  assert.equal(upfront, 0);
+  assert.equal(completion, 0);
+});
+
+test('halves always sum to the exact total across a range of odd values', () => {
+  for (const total of [0.01, 1.01, 99.99, 12345.67, 1000000.05, 33.33]) {
+    const { upfront, completion } = split5050(total);
+    assert.equal(
+      Math.round((upfront + completion) * 100),
+      Math.round(total * 100),
+      `halves must reconcile for ${total}`
+    );
+  }
+});
+
+test('exposes the canonical split-term string', () => {
+  assert.equal(PAYMENT_TERM_SPLIT, '50% Upfront / 50% on Completion');
+});

--- a/tests/php/commercial_moving_test.php
+++ b/tests/php/commercial_moving_test.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Integration test for the Commercial Moving bid type + 50/50 payment term.
+ *
+ * Covers the server-side pieces of the feature:
+ *   • ProposalRepository::split_5050 reconciles to the exact total (odd cents / zero)
+ *   • ProposalRepository::is_split_term recognises only the canonical split string
+ *   • print_service treats the 50/50 term as a ×1 payment schedule (no uplift) —
+ *     identical output to Net 30, unlike Net 30/CC (×1.03)
+ *   • the "Commercial Moving" bid type surfaces via TypeOfBidRepository::get_all
+ *     once the migration is applied (self-cleaning — removes a row it inserts)
+ *
+ * Run:  docker exec lamp-php84 php /var/www/html/rfq/tests/php/commercial_moving_test.php
+ */
+
+$root = __DIR__ . '/../../';
+require_once $root . 'app/Bootstrap/config.inc.php';
+require_once $root . 'app/Bootstrap/Conexion.inc.php';
+require_once $root . 'app/Service/Service.inc.php';
+require_once $root . 'app/Utilities/ProposalRepository.inc.php';
+require_once $root . 'app/TypeOfBid/TypeOfBid.inc.php';
+require_once $root . 'app/TypeOfBid/TypeOfBidRepository.inc.php';
+
+$SPLIT = '50% Upfront / 50% on Completion';
+
+$pass = 0; $fail = 0;
+function check($label, $expected, $actual) {
+  global $pass, $fail;
+  $ok = $expected === $actual;
+  if ($ok) { $pass++; echo "  PASS  $label\n"; }
+  else     { $fail++; echo "  FAIL  $label — expected " . var_export($expected, true) . ", got " . var_export($actual, true) . "\n"; }
+}
+
+/* ---------- split_5050 reconciliation ---------- */
+$clean = ProposalRepository::split_5050(25000);
+check('split 25000 upfront',    12500.0, (float) $clean['upfront']);
+check('split 25000 completion', 12500.0, (float) $clean['completion']);
+
+$odd = ProposalRepository::split_5050(8749.55);
+check('split odd upfront (extra cent)', 4374.78, (float) $odd['upfront']);
+check('split odd completion',           4374.77, (float) $odd['completion']);
+check('split odd reconciles to exact total', 874955, (int) round(($odd['upfront'] + $odd['completion']) * 100));
+
+$zero = ProposalRepository::split_5050(0);
+check('split zero upfront',    0.0, (float) $zero['upfront']);
+check('split zero completion', 0.0, (float) $zero['completion']);
+
+/* ---------- is_split_term ---------- */
+check('is_split_term(split)',      true,  ProposalRepository::is_split_term($SPLIT));
+check('is_split_term(Net 30)',     false, ProposalRepository::is_split_term('Net 30'));
+check('is_split_term(Net 30/CC)',  false, ProposalRepository::is_split_term('Net 30/CC'));
+
+/* ---------- print_service treats 50/50 as ×1 (no uplift) ---------- */
+$service = new Service(1, 1, 'On-site AV integration labor', 80, 150.00, 12000.00, 0, null);
+$split_html  = ProposalRepository::print_service($SPLIT, $service, 1);
+$net30_html  = ProposalRepository::print_service('Net 30', $service, 1);
+$cc_html     = ProposalRepository::print_service('Net 30/CC', $service, 1);
+check('50/50 service output equals Net 30 (×1, no uplift)', $net30_html, $split_html);
+check('50/50 service keeps base unit price $150.00', true, strpos($split_html, '$ 150.00') !== false);
+check('Net 30/CC service applies ×1.03 uplift ($154.50)', true, strpos($cc_html, '$ 154.50') !== false);
+
+/* ---------- Commercial Moving bid type surfaces in the dropdown ---------- */
+Conexion::abrir_conexion();
+$conexion = Conexion::obtener_conexion();
+
+$has = function () use ($conexion) {
+  foreach (TypeOfBidRepository::get_all($conexion) as $t) {
+    if ($t->get_type_of_bid() === 'Commercial Moving') return true;
+  }
+  return false;
+};
+
+$already = $has();
+if (!$already) {
+  // Apply the migration insert, then clean up the row we added.
+  $conexion->exec(file_get_contents($root . 'sql/commercial_moving_payment_term_migration.sql'));
+}
+check('Commercial Moving present in TypeOfBidRepository::get_all', true, $has());
+if (!$already) {
+  $conexion->exec("DELETE FROM type_of_bids WHERE type_of_bid = 'Commercial Moving'");
+}
+Conexion::cerrar_conexion();
+
+echo "\n$pass passed, $fail failed\n";
+exit($fail === 0 ? 0 : 1);


### PR DESCRIPTION
- Implemented a new payment term "50% Upfront / 50% on Completion" in the quote and re-quote forms.
- Updated frontend logic to calculate and display payment splits dynamically.
- Enhanced PDF templates to reflect the new payment structure.
- Created a shared JavaScript helper for payment split calculations.
- Added unit tests for the payment split functionality.
- Integrated server-side checks for the new payment term in the proposal repository.
- Migrated the "Commercial Moving" bid type to support the new payment term.