### PR TITLE
fix: widen pipeline table Created column so the full date shows

### DIFF
--- a/css/estilos.css
+++ b/css/estilos.css
@@ -3383,7 +3383,7 @@ input.sq-input[type="date"] { font-size: 12.5px; color: #2c3849; }
 .pt-card-sub { font-size: 12px; color: var(--ink-400); }
 .pt-table-wrap { position: relative; }
 .pt-table { width: 100%; table-layout: fixed; border-collapse: collapse; font-size: 13px; }
-.pt-col-id { width: 96px; } .pt-col-created { width: 100px; } .pt-col-channel { width: auto; } .pt-col-email { width: 190px; }
+.pt-col-id { width: 96px; } .pt-col-created { width: 124px; } .pt-col-channel { width: auto; } .pt-col-email { width: 190px; }
 .pt-col-status { width: 168px; } .pt-col-type { width: 178px; } .pt-col-user { width: auto; } .pt-col-watch { width: 48px; }
 .pt-table th {
   text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--ink-500);


### PR DESCRIPTION
The **Created** column in the Bid Pipeline Metrics table view was 100px, which clipped `m/d/Y` dates (e.g. `03/11/2026`). Widened to 124px.

The extra width is absorbed by the auto-width Channel / Designated User columns, so the fixed-layout table still fits its container — no horizontal overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)