### PR TITLE
fix: correct Net 30/CC services total_price rounding tie-break

### DIFF
--- a/app/Service/ServiceRepository.inc.php
+++ b/app/Service/ServiceRepository.inc.php
@@ -246,7 +246,10 @@ class ServiceRepository {
     $payment_term = $payment_term == 'Net 30/CC' ? 1.03 : 1;
     if (isset($connection)) {
       try {
-        $sql = 'UPDATE services SET total_price = quantity * ROUND(unit_price * :payment_term, 2) WHERE id_rfq = :id_rfq';
+        // Cast the bound param to DECIMAL — as a plain placeholder MySQL evaluates the
+        // multiplication in DOUBLE, so exact .xx5 ties (e.g. 10687.50 * 1.03 = 11008.125)
+        // round down to match float representation instead of up like PHP/JS number_format.
+        $sql = 'UPDATE services SET total_price = quantity * ROUND(unit_price * CAST(:payment_term AS DECIMAL(10,4)), 2) WHERE id_rfq = :id_rfq';
         $sentence = $connection->prepare($sql);
         $sentence->bindValue(':id_rfq', $id_rfq, PDO::PARAM_STR);
         $sentence->bindValue(':payment_term', $payment_term, PDO::PARAM_STR);

--- a/sql/services_net30cc_rounding_fix.sql
+++ b/sql/services_net30cc_rounding_fix.sql
@@ -1,0 +1,23 @@
+-- Data fix: correct services.total_price for the Net 30/CC penny tie-rounding bug
+-- (see app/Service/ServiceRepository.inc.php calc_items_with_CC).
+--
+-- ROUND(unit_price * :payment_term, 2), with :payment_term bound as a plain PDO
+-- parameter, made MySQL evaluate the multiplication in DOUBLE precision. For unit
+-- prices whose *1.03 result lands exactly on a half-cent (e.g. 10687.50 * 1.03 =
+-- 11008.125), DOUBLE rounds the tie down where PHP/JS — used everywhere else this
+-- number is computed and displayed (app table, PDF unit-price column) — round it
+-- up. The stored total_price ended up a cent short of what the rest of the app
+-- already shows. Fixed going forward by casting the bound param to DECIMAL(10,4).
+--
+-- Scoped to rows off by <= 2 cents (the signature of this specific tie bug) so it
+-- does not touch the unrelated, larger-magnitude services.total_price rows that
+-- were simply never recalculated after their quote's payment term was set to
+-- Net 30/CC — those need a separate investigation, not a blanket recompute.
+--
+-- Idempotent: safe to run more than once, and safe on both local and production.
+
+UPDATE services s
+JOIN rfq r ON r.id = s.id_rfq
+SET s.total_price = ROUND(s.quantity * ROUND(s.unit_price * CAST(1.03 AS DECIMAL(10,4)), 2), 2)
+WHERE r.services_payment_term = 'Net 30/CC'
+  AND ABS(s.total_price - ROUND(s.quantity * ROUND(s.unit_price * CAST(1.03 AS DECIMAL(10,4)), 2), 2)) BETWEEN 0.001 AND 0.02;


### PR DESCRIPTION
## Summary
- `ServiceRepository::calc_items_with_CC()` recalculates `services.total_price` in SQL on every autosave when the Net 30/CC payment term is active. The 1.03 multiplier was bound as a plain PDO parameter, so MySQL evaluated `unit_price * :payment_term` in DOUBLE precision instead of DECIMAL. For unit prices whose product lands exactly on a half-cent (e.g. `10687.50 * 1.03 = 11008.125`), DOUBLE rounds the tie **down**, while PHP's `number_format()` and JS's `.toFixed()` — used everywhere else this number is computed/displayed (the edit-quote table, the PDF's own unit-price column) — round it **up**. Result: a service's unit price and total disagreed by a cent in the generated PDF (reported on quote 122798).
- Fix: cast the bound parameter to `DECIMAL(10,4)` in the SQL so MySQL's rounding matches PHP/JS.
- Adds `sql/services_net30cc_rounding_fix.sql`, an idempotent data migration that recomputes `total_price` only for rows off by ≤ 2 cents (this bug's signature) — 13 rows across the DB, including quote 122798. It deliberately does **not** touch a separate, larger-magnitude set of ~38 rows (across 20 quotes) that were found during the audit where `total_price` was never multiplied at all after their payment term was set to Net 30/CC — that looks like a different, unrelated staleness issue and needs its own investigation before any data change.

## Test plan
- [x] Reproduced the exact tie case against local MySQL (`ROUND(10687.50 * 1.03, 2)` as a bound param → `11008.12`; literal → `11008.13`)
- [x] Verified the DECIMAL cast fix returns `11008.13` for the same bound-param query
- [x] Ran the migration locally: 12 rows corrected (quote 122798's row was already hand-corrected while diagnosing), 0 small-tie mismatches remain, the 38 unrelated stale rows are untouched
- [ ] Run `sql/services_net30cc_rounding_fix.sql` against production after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)