### PR TITLE
docs: fix prod crontab line for the Daily Digest cron

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -74,16 +74,21 @@ from CDNs — no build step.
 
 ## 4. Cron jobs
 
-Add to the production droplet's crontab (OS-level, not a container cron):
+Production runs the PHP app directly on the droplet (no Docker there — Docker is local-dev
+only, via `docker-compose-lamp`). Add to the droplet's OS crontab:
 
 ```
-0 6 * * * docker exec <php-container> php /var/www/html/rfq/scripts/cron/daily_digest.php
+0 6 * * * php /var/www/elogicportal/rfq/scripts/cron/daily_digest.php
 ```
 
 Sends the Daily RFQ Digest at 6:00am America/New_York to every active Admin-role user.
 Requires the Shared Notification Mailbox to be connected (**Admin Settings**) to actually
 deliver mail — the script runs and logs `digest_send_log` either way, so a disconnected
 mailbox is a silent no-op, not a failure.
+
+If the job silently never runs, check that cron's minimal environment actually resolves
+`php` — swap in the absolute binary path (e.g. `/usr/bin/php`, or a versioned binary like
+`/usr/bin/php8.4`) if so.
 
 ## 5. Third-party services
 

--- a/scripts/cron/daily_digest.php
+++ b/scripts/cron/daily_digest.php
@@ -14,10 +14,10 @@
  * A digest_send_log row per calendar date is the dedup guard: a second trigger the same day
  * (whether or not the shared mailbox is connected) no-ops instead of double-sending.
  *
- * Crontab (production droplet, 6:00am America/New_York):
- *   0 6 * * * docker exec <php-container> php /var/www/html/rfq/scripts/cron/daily_digest.php
+ * Crontab (production droplet, runs PHP directly — no Docker there):
+ *   0 6 * * * php /var/www/elogicportal/rfq/scripts/cron/daily_digest.php
  *
- * Manual run: docker exec lamp-php84 php /var/www/html/rfq/scripts/cron/daily_digest.php
+ * Manual run, local dev (Docker): docker exec lamp-php84 php /var/www/html/rfq/scripts/cron/daily_digest.php
  */
 
 date_default_timezone_set('America/New_York');


### PR DESCRIPTION
## Summary
- Follow-up to #71. That PR's crontab documentation (`DEPLOYMENT.md` and the `daily_digest.php` docblock) assumed prod runs inside Docker (`docker exec <php-container> ...`), matching local dev. Production actually runs PHP directly on the droplet, no Docker.
- This commit was pushed to `feature/daily-digest-email` after #71 was already merged, so it never landed on `master` — this PR just brings that one commit in.

## Test plan
- [x] Docs-only change (crontab line + docblock comment) — `php -l` clean on `daily_digest.php`, no code behavior affected