### PR TITLE
fix: restore Pipeline Table View (keep Quote Watchers removed)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 All built. Detail for most of these lives in the matching `###` section below.
 
-Quote Inline Editing · SharePoint Sheet Sync · Comment Mentions & Notifications · Bid Requirement Fields (Site Visit/Q&A Deadline/Resumes) · Bid Pipeline Sync Controls · Bid Pipeline Metrics Dashboard · 3-Year Annual Awards Comparison · Quote Lifecycle Audit Events · Write-Once Sheet Sync · Advanced Quote Search · Commercial Moving bid type + 50/50 payment term · Shared Notification Mailbox · Daily RFQ Digest Email
+Quote Inline Editing · SharePoint Sheet Sync · Comment Mentions & Notifications · Bid Requirement Fields (Site Visit/Q&A Deadline/Resumes) · Bid Pipeline Sync Controls · Bid Pipeline Metrics Dashboard · Pipeline Table View · 3-Year Annual Awards Comparison · Quote Lifecycle Audit Events · Write-Once Sheet Sync · Advanced Quote Search · Commercial Moving bid type + 50/50 payment term · Shared Notification Mailbox · Daily RFQ Digest Email
 
 ## Environment
 
@@ -78,6 +78,12 @@ Endpoint `POST quote/load_unified_audit_trail` queries all three (re-quote joine
 **Win/Loss gotcha:** denominator = `submitted` + `award` + lost (`no_award_*`); sources-sought is excluded. **Dollar-value gotcha:** every money figure = product total + services subtotal via `SERVICES_JOIN`/`VALUE_EXPR`, never `rfq.total_price` alone (count-only aggregations skip the join).
 
 Two listing pages mirror this: Sources Sought (`quote/sources_sought`) and No Award (`quote/no_award`, with a Reason column). Tests: `tests/php/pipeline_metrics_test.php`, `tests/specs/09-pipeline-metrics.spec.js`.
+
+### Pipeline Table View
+
+`Charts | Table` toggle on `perfil/reports/pipeline_metrics` (`#pm-view`) swaps to a filterable, server-paginated (25/row) quote table over the same `created_at` cohort as the charts (`PipelineTableRepository`, `js/pipeline_table.js`). Clicking a row opens a Quote Summary modal (real attached files from `quote/get_quote_files/<id>`, not the `rfq.file_document` checklist field; quick-comment reuses `#comment_rfq`/`mentions.js`).
+
+**No Quote Watchers** — that subsystem (per-quote watch subscriptions + notification fan-out) was built alongside this Table View, then removed; don't reintroduce a `watched` field/join without deliberately re-adding that whole feature. Test: `tests/php/pipeline_table_test.php`.
 
 ### Charts Tab — Annual Awards (3-year)
 

--- a/app/Bootstrap/routes.inc.php
+++ b/app/Bootstrap/routes.inc.php
@@ -216,6 +216,7 @@ define('PIPELINE_METRICS', REPORTS . 'pipeline_metrics');
 define('PIPELINE_METRICS_DATA', QUOTE_SC . 'pipeline_metrics');
 define('PIPELINE_METRICS_DRILLDOWN', QUOTE_SC . 'pipeline_metrics_drilldown');
 define('PIPELINE_METRICS_EXPORT', QUOTE_SC . 'pipeline_metrics_export');
+define('PIPELINE_TABLE', QUOTE_SC . 'pipeline_table');
 /********************************OTHER VIEWS*****************************************/
 define('CHARTS', PERFIL . 'charts');
 define('SEARCH_QUOTES', PERFIL . 'search_quotes');

--- a/app/Report/PipelineTableRepository.inc.php
+++ b/app/Report/PipelineTableRepository.inc.php
@@ -1,0 +1,169 @@
+<?php
+
+/**
+ * PipelineTableRepository
+ *
+ * Server-side data for the Bid Pipeline Metrics "Table" view — a dense, filterable,
+ * paginated list of quotes over the same cohort (rfq.created_at) the charts use.
+ *
+ * Reuses PipelineMetricsRepository's public building blocks so the derived status,
+ * dollar value, and status vocabulary always agree with the charts:
+ *   STATUS_CASE, STATUSES, SERVICES_JOIN, VALUE_EXPR.
+ *
+ * Aggregation/paging is entirely in SQL — never by loading Rfq objects. Filters are
+ * AND-combined; an empty filter set returns every non-deleted quote in the period.
+ * Inverted custom date ranges simply return no rows (no error).
+ */
+class PipelineTableRepository {
+
+  const PAGE_SIZE = 25;
+
+  /**
+   * One page of rows for a period + filters, plus the total count.
+   * @return array ['rows' => [...], 'total' => int, 'page' => int, 'pageSize' => int]
+   */
+  public static function getPage($conexion, array $period, array $filters, $page = 0) {
+    $page = max(0, (int)$page);
+    [$innerWhere, $statusWhere, $params] = self::buildWhere($period, $filters);
+
+    $countSql = "SELECT COUNT(*) FROM (
+        SELECT " . PipelineMetricsRepository::STATUS_CASE . " AS bucket
+        FROM rfq
+        WHERE $innerWhere
+      ) t" . ($statusWhere ? " WHERE $statusWhere" : "");
+    $total = (int)self::scalar($conexion, $countSql, $params);
+
+    $offset = $page * self::PAGE_SIZE;
+    $rowsSql = "SELECT id, email_code, canal, type_of_bid, name, designated_username, value, bucket, created_at
+      FROM (
+        SELECT rfq.id, rfq.email_code, rfq.canal, rfq.type_of_bid, rfq.name, rfq.created_at,
+               u.nombre_usuario AS designated_username,
+               " . PipelineMetricsRepository::VALUE_EXPR . " AS value,
+               " . PipelineMetricsRepository::STATUS_CASE . " AS bucket
+        FROM rfq" . PipelineMetricsRepository::SERVICES_JOIN . "
+        LEFT JOIN usuarios u ON u.id = rfq.usuario_designado
+        WHERE $innerWhere
+      ) t
+      " . ($statusWhere ? "WHERE $statusWhere" : "") . "
+      ORDER BY id DESC
+      LIMIT $offset, " . self::PAGE_SIZE;
+
+    $rows = self::run($conexion, $rowsSql, $params);
+
+    $labels = []; $colors = [];
+    foreach (PipelineMetricsRepository::STATUSES as $s) { $labels[$s['key']] = $s['label']; $colors[$s['key']] = $s['color']; }
+
+    $out = array_map(function ($r) use ($labels, $colors) {
+      $name = trim(preg_replace('/\s+/', ' ', (string)$r['name']));
+      return [
+        'id'          => (int)$r['id'],
+        'code'        => $r['email_code'] !== '' && $r['email_code'] !== null ? $r['email_code'] : ('RFQ-' . $r['id']),
+        'emailCode'   => $r['email_code'] !== '' && $r['email_code'] !== null ? $r['email_code'] : '—',
+        'channel'     => self::displayChannel($r['canal']),
+        'bidType'     => $r['type_of_bid'] !== '' && $r['type_of_bid'] !== null ? $r['type_of_bid'] : 'Uncategorized',
+        'user'        => $r['designated_username'] !== null ? $r['designated_username'] : 'Unassigned',
+        'status'      => $r['bucket'],
+        'statusLabel' => $labels[$r['bucket']] ?? $r['bucket'],
+        'statusColor' => $colors[$r['bucket']] ?? '#9aa6b6',
+        'name'        => $name !== '' ? $name : ('Proposal #' . $r['id']),
+        'value'       => (float)$r['value'],
+        'created'     => !empty($r['created_at']) ? date('m/d/Y', strtotime($r['created_at'])) : '—',
+      ];
+    }, $rows);
+
+    return ['rows' => $out, 'total' => $total, 'page' => $page, 'pageSize' => self::PAGE_SIZE];
+  }
+
+  /** Distinct raw channels present in the data, for the Channel filter dropdown. */
+  public static function getDistinctChannels($conexion) {
+    $sql = "SELECT DISTINCT canal FROM rfq WHERE deleted = 0 AND canal IS NOT NULL AND canal <> '' ORDER BY canal ASC";
+    $rows = self::run($conexion, $sql, []);
+    return array_map(fn($r) => ['value' => $r['canal'], 'label' => self::displayChannel($r['canal'])], $rows);
+  }
+
+  /** Mirrors Rfq::print_channel() for the two renamed channels. */
+  private static function displayChannel($canal) {
+    if ($canal === 'FedBid') return 'Unison';
+    if ($canal === 'FBO') return 'SAM';
+    return (string)$canal;
+  }
+
+  /**
+   * Builds the inner (rfq-level) WHERE and the outer (derived-status) WHERE + params.
+   * @return array [innerWhere, statusWhere, params]
+   */
+  private static function buildWhere(array $period, array $filters) {
+    [$periodSql, $params] = self::periodClause($period);
+    $inner = ["rfq.deleted = 0", $periodSql];
+
+    if (!empty($filters['quoteId'])) {
+      $params[':qid'] = '%' . $filters['quoteId'] . '%';
+      $inner[] = "CAST(rfq.id AS CHAR) LIKE :qid";
+    }
+    if (!empty($filters['channel'])) {
+      $params[':channel'] = $filters['channel'];
+      $inner[] = "rfq.canal = :channel";
+    }
+    if (!empty($filters['emailCode'])) {
+      $params[':ec'] = '%' . $filters['emailCode'] . '%';
+      $inner[] = "rfq.email_code LIKE :ec";
+    }
+    if (!empty($filters['bidType'])) {
+      $params[':bt'] = $filters['bidType'];
+      $inner[] = "rfq.type_of_bid = :bt";
+    }
+    if (!empty($filters['user'])) {
+      $params[':uid'] = (int)$filters['user'];
+      $inner[] = "rfq.usuario_designado = :uid";
+    }
+
+    $statusWhere = '';
+    if (!empty($filters['statuses']) && is_array($filters['statuses'])) {
+      $validKeys = array_column(PipelineMetricsRepository::STATUSES, 'key');
+      $keys = array_values(array_intersect($filters['statuses'], $validKeys));
+      if (!empty($keys)) {
+        $ph = [];
+        foreach ($keys as $i => $k) { $ph[] = ":st$i"; $params[":st$i"] = $k; }
+        $statusWhere = "bucket IN (" . implode(',', $ph) . ")";
+      }
+    }
+
+    return [implode(' AND ', $inner), $statusWhere, $params];
+  }
+
+  /** Period WHERE fragment on rfq.created_at. Adds a custom from/to range for the table. */
+  private static function periodClause(array $period) {
+    $col = "rfq.created_at";
+    $mode = $period['mode'] ?? 'year';
+
+    if ($mode === 'custom') {
+      $sql = "$col IS NOT NULL AND DATE($col) BETWEEN :cfrom AND :cto";
+      return [$sql, [':cfrom' => (string)$period['from'], ':cto' => (string)$period['to']]];
+    }
+
+    $sql = "$col IS NOT NULL AND YEAR($col) = :year";
+    $params = [':year' => (int)$period['year']];
+    if ($mode === 'quarter') {
+      $sql .= " AND QUARTER($col) = :quarter";
+      $params[':quarter'] = (int)$period['quarter'];
+    } elseif ($mode === 'month') {
+      $sql .= " AND MONTH($col) = :month";
+      $params[':month'] = (int)$period['month'];
+    }
+    return [$sql, $params];
+  }
+
+  private static function scalar($conexion, $sql, array $params) {
+    $stmt = $conexion->prepare($sql);
+    foreach ($params as $n => $v) { $stmt->bindValue($n, $v, is_int($v) ? PDO::PARAM_INT : PDO::PARAM_STR); }
+    $stmt->execute();
+    return $stmt->fetchColumn();
+  }
+
+  private static function run($conexion, $sql, array $params) {
+    $stmt = $conexion->prepare($sql);
+    foreach ($params as $n => $v) { $stmt->bindValue($n, $v, is_int($v) ? PDO::PARAM_INT : PDO::PARAM_STR); }
+    $stmt->execute();
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+  }
+}

--- a/css/estilos.css
+++ b/css/estilos.css
@@ -3264,3 +3264,233 @@ input.sq-input[type="date"] { font-size: 12.5px; color: #2c3849; }
 }
 .sq-empty-title { font-size: 14px; font-weight: 600; color: #0f1623; }
 .sq-empty-sub { font-size: 12.5px; color: #7d8ba0; margin-top: 3px; max-width: 340px; margin-left: auto; margin-right: auto; }
+
+/* =========================================================================
+   Pipeline Table View + Quote Watchers
+   Custom date range on the period bar, the pt-* table, and the qs-* Quote
+   Summary modal. The pt-/qs- rules are ported from the Claude Design handoff;
+   the design's bare tokens (--ink-*, --sky, --line…) are supplied below,
+   scoped to the table view and modal so they don't collide with --pm-*/--nf-*.
+   ========================================================================= */
+
+/* custom date range (period bar) — uses the pm-dashboard token set */
+.pm-daterange { display: inline-flex; align-items: center; gap: 8px; }
+.pm-date {
+  height: 32px; padding: 0 10px; border: 1px solid var(--pm-line); border-radius: 8px;
+  background: #fff; font: inherit; font-size: 12.5px; color: var(--pm-ink-700); cursor: pointer;
+  font-variant-numeric: tabular-nums;
+}
+.pm-date:focus { outline: 0; border-color: var(--pm-sky); box-shadow: 0 0 0 3px rgba(45,180,232,0.18); }
+.pm-date-sep { font-size: 12px; color: var(--pm-ink-400); }
+
+/* design tokens scoped to the table view + modal */
+#pm-table-view, .qs-scrim {
+  --ink-900:#0f1623; --ink-700:#2c3849; --ink-500:#5a6a7e; --ink-400:#7d8ba0; --ink-300:#aab4c2;
+  --line:#e3e7ee; --line-2:#eef1f6; --navy-50:#f4f6fa;
+  --sky:#2db4e8; --sky-600:#1aa2dc; --sky-50:#e6f5fc;
+  --green:#16a34a; --green-600:#15803d; --green-50:#e8f6ec;
+  --amber:#d97706; --amber-50:#fdf2dc; --radius:12px;
+  font-family: 'Manrope', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+#pm-table-view *, .qs-scrim * { box-sizing: border-box; }
+
+/* filter row */
+.pt-filters {
+  margin-top: 16px; background: white; border: 1px solid var(--line); border-radius: var(--radius);
+  padding: 14px 16px 12px; box-shadow: 0 1px 2px rgba(15,22,35,0.03);
+}
+.pt-filters-grid { display: grid; grid-template-columns: repeat(6, 1fr); gap: 12px; }
+.pt-field { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
+.pt-field-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; font-weight: 700; color: var(--ink-700); }
+.pt-input {
+  height: 36px; padding: 0 10px; width: 100%; border: 1px solid var(--line); border-radius: 8px; background: white;
+  font: inherit; font-size: 13px; color: var(--ink-900); transition: border-color .12s, box-shadow .12s;
+}
+.pt-input::placeholder { color: var(--ink-400); }
+.pt-input:hover { border-color: #c7d0dd; }
+.pt-input:focus { outline: 0; border-color: var(--sky); box-shadow: 0 0 0 3px rgba(45,180,232,0.18); }
+.pt-select-wrap { position: relative; display: block; }
+.pt-select {
+  appearance: none; cursor: pointer; padding-right: 30px;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%237d8ba0' stroke-width='2.4' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>");
+  background-repeat: no-repeat; background-position: right 9px center;
+}
+.pt-filters-foot {
+  display: flex; align-items: center; justify-content: space-between; gap: 10px;
+  margin-top: 12px; padding-top: 11px; border-top: 1px solid var(--line-2);
+}
+.pt-filters-count { font-size: 12px; color: var(--ink-400); }
+.pt-clear-btn {
+  display: inline-flex; align-items: center; gap: 6px; height: 30px; padding: 0 11px;
+  border: 1px solid var(--line); border-radius: 7px; background: white;
+  font: inherit; font-size: 12px; font-weight: 600; color: var(--ink-500); cursor: pointer; transition: all .12s;
+}
+.pt-clear-btn:hover:not(:disabled) { background: var(--navy-50); color: var(--ink-900); }
+.pt-clear-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+/* status multi-select */
+.pt-ms-wrap { position: relative; }
+.pt-ms-trigger { display: flex; align-items: center; gap: 8px; padding-right: 30px; text-align: left; cursor: pointer; position: relative; overflow: hidden; }
+.pt-ms-trigger.is-open { border-color: var(--sky); box-shadow: 0 0 0 3px rgba(45,180,232,0.18); }
+.pt-ms-summary { display: flex; align-items: center; min-width: 0; overflow: hidden; }
+.pt-ms-caret { position: absolute; right: 9px; top: 50%; transform: translateY(-50%); color: var(--ink-400); pointer-events: none; }
+.pt-ms-placeholder { color: var(--ink-400); font-size: 13px; }
+.pt-ms-pills { display: flex; align-items: center; gap: 5px; min-width: 0; overflow: hidden; }
+.pt-ms-more { font-size: 11.5px; font-weight: 600; color: var(--ink-500); white-space: nowrap; }
+.pt-ms-menu {
+  position: absolute; z-index: 30; top: calc(100% + 6px); left: 0; min-width: 270px;
+  background: white; border: 1px solid var(--line); border-radius: 10px;
+  box-shadow: 0 12px 34px rgba(15,22,35,0.16); overflow: hidden;
+}
+.pt-ms-menu-head {
+  display: flex; align-items: center; justify-content: space-between; gap: 8px;
+  padding: 9px 12px; border-bottom: 1px solid var(--line-2); background: #fafbfd;
+  font-size: 11.5px; color: var(--ink-500); font-weight: 500;
+}
+.pt-ms-clear { border: 0; background: transparent; font: inherit; font-size: 11.5px; font-weight: 700; color: var(--sky-600); cursor: pointer; padding: 0; }
+.pt-ms-clear:hover { text-decoration: underline; }
+.pt-ms-list { max-height: 288px; overflow-y: auto; padding: 5px; }
+.pt-ms-opt {
+  display: flex; align-items: center; gap: 9px; width: 100%; padding: 7px 8px; border: 0; border-radius: 7px;
+  background: transparent; font: inherit; font-size: 13px; color: var(--ink-700); cursor: pointer; text-align: left; transition: background .1s;
+}
+.pt-ms-opt:hover { background: var(--navy-50); }
+.pt-ms-opt.is-on { color: var(--ink-900); font-weight: 600; }
+.pt-ms-check {
+  flex-shrink: 0; width: 16px; height: 16px; border-radius: 5px; border: 1.5px solid var(--ink-300);
+  background: white; color: white; display: grid; place-items: center; transition: background .12s, border-color .12s;
+}
+.pt-ms-check.is-on { background: var(--sky); border-color: var(--sky); }
+.pt-ms-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+.pt-ms-label { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+/* status pill */
+.pt-pill {
+  display: inline-flex; align-items: center; gap: 6px; height: 22px; padding: 0 9px; border-radius: 12px; white-space: nowrap;
+  font-size: 11.5px; font-weight: 600; color: var(--ink-900);
+  background: color-mix(in srgb, var(--c) 12%, white); border: 1px solid color-mix(in srgb, var(--c) 26%, white);
+  max-width: 100%; overflow: hidden; text-overflow: ellipsis;
+}
+.pt-pill-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--c); flex-shrink: 0; }
+
+/* table card */
+.pt-card {
+  margin-top: 16px; background: white; border: 1px solid var(--line); border-radius: var(--radius);
+  box-shadow: 0 1px 2px rgba(15,22,35,0.03); overflow: hidden;
+}
+.pt-card-head { display: flex; align-items: baseline; gap: 10px; padding: 14px 16px 12px; border-bottom: 1px solid var(--line-2); }
+.pt-card-title { font-size: 14px; font-weight: 700; color: var(--ink-900); }
+.pt-card-sub { font-size: 12px; color: var(--ink-400); }
+.pt-table-wrap { position: relative; }
+.pt-table { width: 100%; table-layout: fixed; border-collapse: collapse; font-size: 13px; }
+.pt-col-id { width: 96px; } .pt-col-created { width: 124px; } .pt-col-channel { width: auto; } .pt-col-email { width: 190px; }
+.pt-col-status { width: 168px; } .pt-col-type { width: 178px; } .pt-col-user { width: auto; } .pt-col-watch { width: 48px; }
+.pt-table th {
+  text-align: left; font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--ink-500);
+  font-weight: 700; padding: 11px 14px; border-bottom: 1px solid var(--line); background: #fafbfd; white-space: nowrap;
+}
+.pt-table td {
+  padding: 11px 14px; border-bottom: 1px solid var(--line-2); color: var(--ink-700); vertical-align: middle;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.pt-table tbody tr { transition: background .1s; }
+.pt-table tbody tr:hover { background: #fafbfd; }
+.pt-table tbody tr:last-child td { border-bottom: 0; }
+.pt-td-ellip { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.pt-td-mono { font-variant-numeric: tabular-nums; color: var(--ink-500); }
+.pt-td-id { font-variant-numeric: tabular-nums; }
+.pt-idlink { border: 0; background: transparent; padding: 0; font: inherit; font-size: 13px; font-weight: 700; color: var(--sky-600); cursor: pointer; font-variant-numeric: tabular-nums; }
+.pt-idlink:hover { text-decoration: underline; }
+.pt-th-watch { text-align: center; padding: 0; }
+.pt-th-watch-glyph { color: var(--ink-300); font-size: 13px; line-height: 1; }
+.pt-td-watch { text-align: center; padding: 4px 4px; }
+.pt-watch {
+  width: 34px; height: 34px; display: inline-grid; place-items: center; border: 0; background: transparent;
+  border-radius: 8px; cursor: pointer; color: var(--ink-300); transition: color .12s, background .12s;
+}
+.pt-watch:hover { background: var(--navy-50); color: var(--amber); }
+.pt-watch.is-on { color: #e9a107; }
+.pt-watch.is-on:hover { color: #d97706; background: var(--amber-50); }
+.pt-watch:focus-visible { outline: 2px solid var(--sky); outline-offset: 1px; }
+.pt-empty { padding: 56px 24px; text-align: center; display: flex; flex-direction: column; align-items: center; gap: 5px; }
+.pt-empty-ico { width: 52px; height: 52px; border-radius: 14px; display: grid; place-items: center; background: var(--navy-50); color: var(--ink-300); margin-bottom: 4px; }
+.pt-empty-title { font-size: 13.5px; font-weight: 700; color: var(--ink-700); }
+.pt-empty-sub { font-size: 12px; color: var(--ink-400); }
+.pt-pager-bar { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 12px 16px; border-top: 1px solid var(--line-2); flex-wrap: wrap; }
+.pt-pager-meta { font-size: 12px; color: var(--ink-400); }
+.pt-pager-meta strong { color: var(--ink-700); font-weight: 700; }
+.pt-pager { display: flex; gap: 4px; }
+.pt-page-btn {
+  min-width: 30px; height: 30px; padding: 0 8px; border: 1px solid var(--line); border-radius: 7px; background: white;
+  font: inherit; font-size: 12.5px; font-weight: 600; color: var(--ink-500); cursor: pointer; transition: all .12s; font-variant-numeric: tabular-nums;
+}
+.pt-page-btn:hover:not(:disabled):not(.is-active) { background: var(--navy-50); color: var(--ink-900); }
+.pt-page-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.pt-page-btn.is-active { background: var(--sky); border-color: var(--sky); color: white; }
+.pt-page-gap { min-width: 22px; text-align: center; color: var(--ink-300); font-size: 12.5px; align-self: center; }
+@media (max-width: 1120px) { .pt-filters-grid { grid-template-columns: repeat(3, 1fr); } }
+@media (max-width: 720px)  { .pt-filters-grid { grid-template-columns: repeat(2, 1fr); } }
+
+/* Quote Summary modal */
+.qs-scrim {
+  position: fixed; inset: 0; z-index: 1200; display: flex; align-items: center; justify-content: center; padding: 28px;
+  background: rgba(15,22,35,0.34); animation: qs-fade .18s ease;
+}
+@keyframes qs-fade { from { opacity: 0; } to { opacity: 1; } }
+.qs-modal {
+  width: 480px; max-width: 100%; max-height: 100%; background: white; border-radius: 14px; overflow: hidden;
+  display: flex; flex-direction: column; box-shadow: 0 24px 64px rgba(15,22,35,0.32); animation: qs-pop .2s cubic-bezier(0.22,1,0.36,1);
+}
+@keyframes qs-pop { from { transform: translateY(8px) scale(0.98); opacity: 0; } to { transform: none; opacity: 1; } }
+.qs-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; padding: 18px 18px 16px; border-bottom: 1px solid var(--line-2); background: #fafbfd; }
+.qs-head-main { min-width: 0; }
+.qs-eyebrow { display: flex; align-items: center; gap: 7px; font-size: 11px; color: var(--ink-400); font-weight: 600; }
+.qs-code { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 11px; color: var(--ink-700); padding: 2px 6px; background: white; border: 1px solid var(--line); border-radius: 5px; }
+.qs-eyebrow-sep { color: var(--ink-300); }
+.qs-title { font-size: 24px; font-weight: 800; color: var(--ink-900); letter-spacing: -0.01em; margin-top: 9px; font-variant-numeric: tabular-nums; }
+a.qs-title-link { display: inline-flex; align-items: center; gap: 8px; color: var(--sky-600); text-decoration: none; cursor: pointer; transition: color .12s; }
+a.qs-title-link:hover { color: var(--sky); }
+a.qs-title-link:hover .qs-title-num { text-decoration: underline; }
+.qs-title-ext { flex-shrink: 0; opacity: 0.85; margin-top: 2px; }
+.qs-desc { font-size: 13px; color: var(--ink-500); margin-top: 3px; }
+.qs-close { width: 30px; height: 30px; flex-shrink: 0; display: grid; place-items: center; border: 1px solid var(--line); background: white; border-radius: 8px; color: var(--ink-500); cursor: pointer; transition: all .12s; }
+.qs-close:hover { background: var(--navy-50); color: var(--ink-900); }
+.qs-body { padding: 16px 18px; overflow-y: auto; display: flex; flex-direction: column; gap: 18px; }
+.qs-amount-row { display: flex; align-items: flex-end; justify-content: space-between; gap: 12px; }
+.qs-amount-label { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.06em; font-weight: 700; color: var(--ink-400); }
+.qs-amount { font-size: 30px; font-weight: 800; color: var(--ink-900); line-height: 1.1; letter-spacing: -0.02em; font-variant-numeric: tabular-nums; margin-top: 3px; }
+.qs-watch-btn {
+  display: inline-flex; align-items: center; gap: 7px; flex-shrink: 0; height: 36px; padding: 0 14px; border: 1px solid var(--line);
+  border-radius: 9px; background: white; font: inherit; font-size: 13px; font-weight: 600; color: var(--ink-700); cursor: pointer; transition: all .14s;
+}
+.qs-watch-btn:hover { background: var(--navy-50); border-color: #c7d0dd; }
+.qs-watch-btn.is-on { color: #b8790a; background: var(--amber-50); border-color: color-mix(in srgb, var(--amber) 30%, white); }
+.qs-section-title { font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; font-weight: 700; color: var(--ink-500); margin-bottom: 9px; display: flex; align-items: center; gap: 7px; }
+.qs-count { font-size: 10.5px; font-weight: 700; color: var(--ink-500); background: var(--navy-50); border-radius: 10px; padding: 1px 7px; letter-spacing: 0; }
+.qs-docs { display: flex; flex-direction: column; gap: 6px; }
+.qs-doc { display: flex; align-items: center; gap: 10px; padding: 9px 10px; border: 1px solid var(--line-2); border-radius: 9px; background: white; text-decoration: none; cursor: pointer; transition: border-color .12s, background .12s; }
+.qs-doc:hover { border-color: #cce8f5; background: var(--sky-50); }
+.qs-doc-ico { width: 30px; height: 30px; border-radius: 7px; flex-shrink: 0; display: grid; place-items: center; color: var(--dc); background: color-mix(in srgb, var(--dc) 12%, white); }
+.qs-doc-name { flex: 1; min-width: 0; font-size: 13px; font-weight: 500; color: var(--ink-900); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.qs-doc-dl { color: var(--ink-300); flex-shrink: 0; display: grid; place-items: center; transition: color .12s; }
+.qs-doc:hover .qs-doc-dl { color: var(--sky-600); }
+.qs-fields { display: grid; grid-template-columns: 1fr 1fr; gap: 12px 16px; }
+.qs-field { display: flex; flex-direction: column; gap: 5px; min-width: 0; }
+.qs-field-label { font-size: 11px; color: var(--ink-400); font-weight: 600; }
+.qs-field-val { font-size: 13px; font-weight: 600; color: var(--ink-900); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.qs-foot { border-top: 1px solid var(--line-2); padding: 12px 18px 14px; position: relative; }
+.qs-confirm {
+  display: inline-flex; align-items: center; gap: 6px; margin-bottom: 9px; font-size: 12px; font-weight: 700; color: var(--green-600);
+  background: var(--green-50); border: 1px solid color-mix(in srgb, var(--green) 22%, white); padding: 5px 10px; border-radius: 8px; animation: qs-fade .2s ease;
+}
+.qs-comment { display: flex; align-items: center; gap: 8px; }
+.qs-comment-input {
+  flex: 1; height: 40px; min-height: 40px; padding: 9px 13px; border: 1px solid var(--line); border-radius: 10px; background: white;
+  font: inherit; font-size: 13px; color: var(--ink-900); transition: border-color .12s, box-shadow .12s; resize: none; line-height: 1.4;
+}
+.qs-comment-input::placeholder { color: var(--ink-400); }
+.qs-comment-input:focus { outline: 0; border-color: var(--sky); box-shadow: 0 0 0 3px rgba(45,180,232,0.18); }
+.qs-send { width: 40px; height: 40px; flex-shrink: 0; display: grid; place-items: center; border: 0; border-radius: 10px; background: var(--sky); color: white; cursor: pointer; transition: background .14s, opacity .14s; }
+.qs-send:hover:not(:disabled) { background: var(--sky-600); }
+.qs-send:disabled { opacity: 0.4; cursor: not-allowed; }
+@media (max-width: 560px) { .qs-scrim { padding: 0; align-items: flex-end; } .qs-modal { width: 100%; max-height: 92%; border-radius: 16px 16px 0 0; } }

--- a/index.php
+++ b/index.php
@@ -19,7 +19,7 @@ spl_autoload_register(function ($class) {
     'Fulfillment' => ['FulfillmentRepository', 'FulfillmentItem', 'FulfillmentItemRepository', 'FulfillmentSubitem', 'FulfillmentSubitemRepository', 'FulfillmentService', 'FulfillmentServiceRepository', 'FulfillmentAuditTrailRepository'],
     'ProviderList' => ['ProviderList', 'ProviderListRepository'],
     'PaymentTerm' => ['PaymentTerm', 'PaymentTermRepository'],
-    'Report' => ['Report', 'PipelineMetricsRepository', 'DigestRepository'],
+    'Report' => ['Report', 'PipelineMetricsRepository', 'PipelineTableRepository', 'DigestRepository'],
     'Task' => ['Task', 'TaskRepository'],
     'TaskComment' => ['TaskComment', 'TaskCommentRepository'],
     'TypeOfContract' => ['TypeOfContract', 'TypeOfContractRepository'],
@@ -171,6 +171,9 @@ switch ($partes_ruta[1] ?? null) {
         break;
       case 'pipeline_metrics_export':
         $ruta_elegida = 'scripts/quote/pipeline_metrics_export.php';
+        break;
+      case 'pipeline_table':
+        $ruta_elegida = 'scripts/quote/pipeline_table.php';
         break;
       case 'ids':
         $ruta_elegida = 'scripts/quote/ids.php';

--- a/js/pipeline_metrics.js
+++ b/js/pipeline_metrics.js
@@ -22,6 +22,7 @@
   var state = {
     period: { mode: 'year', year: CFG.year, quarter: Math.floor((CFG.month - 1) / 3) + 1, month: CFG.month },
     show: 'count',
+    view: 'charts',
     data: null
   };
   var charts = {};        // key -> ApexCharts instance
@@ -396,18 +397,47 @@
     state.period = next;
     closeDrill();
     syncPeriodUI();
-    fetchMetrics();
+    if (state.view === 'table') {
+      if (window.PipelineTable) window.PipelineTable.setPeriod(state.period);
+    } else {
+      fetchMetrics();
+    }
   }
   function syncPeriodUI() {
-    var p = state.period;
+    var p = state.period, custom = p.mode === 'custom';
     $$('#pm-mode .pm-seg-btn').forEach(function (b) { b.classList.toggle('is-active', b.dataset.mode === p.mode); });
     $('#pm-year-value').textContent = p.year;
     $('#pm-year-prev').disabled = p.year <= CFG.minYear;
     $('#pm-year-next').disabled = p.year >= CFG.maxYear;
+    var stepper = $('.pm-stepper'); if (stepper) stepper.style.display = custom ? 'none' : '';
     $('#pm-quarter').style.display = p.mode === 'quarter' ? '' : 'none';
     $('#pm-month-wrap').style.display = p.mode === 'month' ? '' : 'none';
+    $('#pm-daterange').style.display = custom ? '' : 'none';
     if (p.mode === 'quarter') $$('#pm-quarter .pm-seg-btn').forEach(function (b) { b.classList.toggle('is-active', +b.dataset.quarter === p.quarter); });
     if (p.mode === 'month') $('#pm-month').value = p.month;
+    if (custom) { $('#pm-date-from').value = p.from || ''; $('#pm-date-to').value = p.to || ''; }
+  }
+
+  /* charts <-> table view toggle */
+  function applyView(view) {
+    // custom range is table-only; drop back to year when returning to charts
+    if (view === 'charts' && state.period.mode === 'custom') {
+      state.period = Object.assign({}, state.period, { mode: 'year' });
+    }
+    state.view = view;
+    var isTable = view === 'table';
+    $$('#pm-view .pm-seg-btn').forEach(function (b) { b.classList.toggle('is-active', b.dataset.view === view); });
+    $('#pm-kpis').style.display = isTable ? 'none' : '';
+    $('#pm-periodbar-right').style.display = isTable ? 'none' : '';
+    $('#pm-charts-body').hidden = isTable;
+    $('#pm-table-view').hidden = !isTable;
+    var customBtn = $('.pm-mode-custom'); if (customBtn) customBtn.style.display = isTable ? '' : 'none';
+    syncPeriodUI();
+    if (isTable) {
+      if (window.PipelineTable) window.PipelineTable.activate(state.period);
+    } else {
+      if (!state.data) fetchMetrics(); else { render(); window.dispatchEvent(new Event('resize')); }
+    }
   }
 
   function wire() {
@@ -416,6 +446,10 @@
         var next = Object.assign({}, state.period, { mode: b.dataset.mode });
         if (next.mode === 'quarter' && !next.quarter) next.quarter = 1;
         if (next.mode === 'month' && !next.month) next.month = CFG.month;
+        if (next.mode === 'custom') {
+          if (!next.from) next.from = next.year + '-01-01';
+          if (!next.to) next.to = next.year + '-12-31';
+        }
         changePeriod(next);
       });
     });
@@ -441,6 +475,15 @@
     $('#pm-drawer-close').addEventListener('click', closeDrill);
     $('#pm-scrim').addEventListener('click', closeDrill);
     document.addEventListener('keydown', function (e) { if (e.key === 'Escape') closeDrill(); });
+
+    // Charts | Table view toggle
+    $$('#pm-view .pm-seg-btn').forEach(function (b) {
+      b.addEventListener('click', function () { if (state.view !== b.dataset.view) applyView(b.dataset.view); });
+    });
+    // custom date range inputs (table view only)
+    var df = $('#pm-date-from'), dt = $('#pm-date-to');
+    if (df) df.addEventListener('change', function () { changePeriod(Object.assign({}, state.period, { mode: 'custom', from: this.value })); });
+    if (dt) dt.addEventListener('change', function () { changePeriod(Object.assign({}, state.period, { mode: 'custom', to: this.value })); });
   }
 
   document.addEventListener('DOMContentLoaded', function () {

--- a/js/pipeline_table.js
+++ b/js/pipeline_table.js
@@ -1,0 +1,369 @@
+/* =========================================================================
+   Bid Pipeline Metrics — Table view controller (vanilla JS)
+   Companion to pipeline_metrics.js. The Charts|Table toggle (owned by
+   pipeline_metrics.js) calls window.PipelineTable.activate()/setPeriod();
+   this file owns the filters, the paginated table, and the Quote Summary
+   modal. Server-side filtered + paginated (25/page).
+   ========================================================================= */
+(function () {
+  'use strict';
+  var CFG = window.PM_CONFIG;
+  if (!CFG) return;
+
+  var $  = function (s, c) { return (c || document).querySelector(s); };
+  var $$ = function (s, c) { return Array.prototype.slice.call((c || document).querySelectorAll(s)); };
+
+  var STATUSES = window.PM_STATUSES || [];
+  var STATUS_BY_KEY = {};
+  STATUSES.forEach(function (s) { STATUS_BY_KEY[s.key] = s; });
+
+  var EMPTY_FILTERS = function () { return { quoteId: '', channel: '', emailCode: '', statuses: [], bidType: '', user: '' }; };
+
+  var st = {
+    period: null,
+    filters: EMPTY_FILTERS(),
+    page: 0,
+    total: 0,
+    rows: [],
+    token: 0,
+    ready: false,
+    openId: null   // id of the quote whose modal is open, or null
+  };
+
+  /* ---------- formatting ---------- */
+  function fmtMoneyFull(n) { return '$' + Math.round(n || 0).toLocaleString('en-US'); }
+  function esc(s) {
+    return String(s == null ? '' : s).replace(/[&<>"]/g, function (c) {
+      return ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c];
+    });
+  }
+
+  function statusPill(key) {
+    var s = STATUS_BY_KEY[key];
+    if (!s) return '';
+    return '<span class="pt-pill" style="--c:' + s.color + '"><span class="pt-pill-dot"></span>' + esc(s.label) + '</span>';
+  }
+  /* ---------- filter helpers ---------- */
+  function countFilters() {
+    var f = st.filters, n = 0;
+    if (f.quoteId.trim()) n++;
+    if (f.channel) n++;
+    if (f.emailCode.trim()) n++;
+    if (f.statuses.length) n++;
+    if (f.bidType) n++;
+    if (f.user) n++;
+    return n;
+  }
+
+  function buildQuery() {
+    var p = st.period, f = st.filters, q = ['mode=' + p.mode, 'year=' + p.year, 'page=' + st.page];
+    if (p.mode === 'quarter') q.push('quarter=' + p.quarter);
+    if (p.mode === 'month') q.push('month=' + p.month);
+    if (p.mode === 'custom') { q.push('from=' + encodeURIComponent(p.from || '')); q.push('to=' + encodeURIComponent(p.to || '')); }
+    if (f.quoteId.trim()) q.push('quoteId=' + encodeURIComponent(f.quoteId.trim()));
+    if (f.channel) q.push('channel=' + encodeURIComponent(f.channel));
+    if (f.emailCode.trim()) q.push('emailCode=' + encodeURIComponent(f.emailCode.trim()));
+    if (f.bidType) q.push('bidType=' + encodeURIComponent(f.bidType));
+    if (f.user) q.push('user=' + encodeURIComponent(f.user));
+    f.statuses.forEach(function (k) { q.push('statuses[]=' + encodeURIComponent(k)); });
+    return q.join('&');
+  }
+
+  /* ---------- fetch + render ---------- */
+  function fetchRows() {
+    var token = ++st.token;
+    $('#pt-card-sub').textContent = 'Loading…';
+    fetch(CFG.tableUrl + '?' + buildQuery(), { credentials: 'same-origin' })
+      .then(function (r) { return r.json(); })
+      .then(function (res) {
+        if (token !== st.token) return;
+        st.rows = res.rows || [];
+        st.total = res.total || 0;
+        st.page = res.page || 0;
+        renderTable();
+      })
+      .catch(function () { if (token === st.token) $('#pt-card-sub').textContent = 'Failed to load quotes.'; });
+  }
+
+  function renderTable() {
+    var tbody = $('#pt-tbody');
+    var anyFilters = countFilters() > 0;
+    $('#pt-card-sub').textContent = st.total + (st.total === 1 ? ' quote' : ' quotes') + ' in this period';
+
+    if (st.rows.length === 0) {
+      tbody.innerHTML = '<tr><td colspan="7"><div class="pt-empty">'
+        + '<div class="pt-empty-ico"><svg width="30" height="30" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="M7 14l3-3 3 2 4-5" opacity="0.45"/></svg></div>'
+        + '<div class="pt-empty-title">No data for this period</div>'
+        + '<div class="pt-empty-sub">' + (anyFilters ? 'Try removing a filter, or a different period.' : 'Try a different year, quarter, or month.') + '</div>'
+        + '</div></td></tr>';
+    } else {
+      tbody.innerHTML = st.rows.map(function (b) {
+        return '<tr data-row="' + b.id + '">'
+          + '<td class="pt-td-id"><button type="button" class="pt-idlink" data-open="' + b.id + '">' + esc(b.id) + '</button></td>'
+          + '<td class="pt-td-mono">' + esc(b.created) + '</td>'
+          + '<td class="pt-td-ellip" title="' + esc(b.channel) + '">' + esc(b.channel) + '</td>'
+          + '<td class="pt-td-mono">' + esc(b.emailCode) + '</td>'
+          + '<td>' + statusPill(b.status) + '</td>'
+          + '<td>' + esc(b.bidType) + '</td>'
+          + '<td class="pt-td-ellip" title="' + esc(b.user) + '">' + esc(b.user) + '</td>'
+          + '</tr>';
+      }).join('');
+    }
+    renderPager();
+    renderFilterFoot();
+  }
+
+  function renderPager() {
+    var host = $('#pt-pager');
+    if (st.total === 0) { host.innerHTML = ''; return; }
+    var pages = Math.max(1, Math.ceil(st.total / 25));
+    var from = st.page * 25 + 1, to = Math.min(st.total, (st.page + 1) * 25);
+    var nums = [], win = 2;
+    for (var i = 0; i < pages; i++) {
+      if (i === 0 || i === pages - 1 || (i >= st.page - win && i <= st.page + win)) nums.push(i);
+      else if (nums[nums.length - 1] !== '…') nums.push('…');
+    }
+    var btns = nums.map(function (n) {
+      return n === '…' ? '<span class="pt-page-gap">…</span>'
+        : '<button class="pt-page-btn ' + (n === st.page ? 'is-active' : '') + '" data-page="' + n + '">' + (n + 1) + '</button>';
+    }).join('');
+    host.className = 'pt-pager-bar';
+    host.innerHTML = '<div class="pt-pager-meta">Showing <strong>' + from + '–' + to + '</strong> of <strong>' + st.total + '</strong> · 25 per page</div>'
+      + '<div class="pt-pager">'
+      + '<button class="pt-page-btn" data-page="' + (st.page - 1) + '" ' + (st.page === 0 ? 'disabled' : '') + ' aria-label="Previous page">‹</button>'
+      + btns
+      + '<button class="pt-page-btn" data-page="' + (st.page + 1) + '" ' + (st.page >= pages - 1 ? 'disabled' : '') + ' aria-label="Next page">›</button>'
+      + '</div>';
+  }
+
+  function renderFilterFoot() {
+    var n = countFilters();
+    $('#pt-filters-count').textContent = n === 0 ? 'No filters applied' : (n + ' filter' + (n === 1 ? '' : 's') + ' applied');
+    $('#pt-clear').disabled = n === 0;
+  }
+
+  /* ---------- status multi-select ---------- */
+  function buildStatusMs() {
+    var host = $('#pt-status-ms');
+    if (!host || host.dataset.built) return;
+    host.dataset.built = '1';
+    host.innerHTML =
+      '<button type="button" class="pt-input pt-ms-trigger" id="pt-ms-trigger">'
+      + '<span class="pt-ms-summary" id="pt-ms-summary"><span class="pt-ms-placeholder">Any status</span></span>'
+      + '<svg class="pt-ms-caret" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>'
+      + '</button>'
+      + '<div class="pt-ms-menu" id="pt-ms-menu" hidden>'
+      + '<div class="pt-ms-menu-head"><span id="pt-ms-head">All statuses match</span><button type="button" class="pt-ms-clear" id="pt-ms-clear">Clear</button></div>'
+      + '<div class="pt-ms-list">'
+      + STATUSES.map(function (s) {
+          return '<button type="button" class="pt-ms-opt" data-key="' + s.key + '">'
+            + '<span class="pt-ms-check"></span>'
+            + '<span class="pt-ms-dot" style="background:' + s.color + '"></span>'
+            + '<span class="pt-ms-label">' + esc(s.label) + '</span></button>';
+        }).join('')
+      + '</div></div>';
+
+    var trigger = $('#pt-ms-trigger'), menu = $('#pt-ms-menu');
+    trigger.addEventListener('click', function () {
+      var open = menu.hidden;
+      menu.hidden = !open;
+      trigger.classList.toggle('is-open', open);
+    });
+    document.addEventListener('mousedown', function (e) {
+      if (!menu.hidden && !host.contains(e.target)) { menu.hidden = true; trigger.classList.remove('is-open'); }
+    });
+    $('#pt-ms-clear').addEventListener('click', function () { st.filters.statuses = []; syncStatusMs(); onFilterChange(); });
+    $$('.pt-ms-opt', menu).forEach(function (opt) {
+      opt.addEventListener('click', function () {
+        var k = opt.dataset.key, arr = st.filters.statuses, i = arr.indexOf(k);
+        if (i >= 0) arr.splice(i, 1); else arr.push(k);
+        syncStatusMs(); onFilterChange();
+      });
+    });
+  }
+
+  function syncStatusMs() {
+    var sel = st.filters.statuses;
+    $$('.pt-ms-opt', $('#pt-ms-menu')).forEach(function (opt) {
+      var on = sel.indexOf(opt.dataset.key) >= 0;
+      opt.classList.toggle('is-on', on);
+      opt.querySelector('.pt-ms-check').classList.toggle('is-on', on);
+      opt.querySelector('.pt-ms-check').innerHTML = on
+        ? '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>' : '';
+    });
+    $('#pt-ms-head').textContent = sel.length === 0 ? 'All statuses match' : (sel.length + ' selected');
+    var sum = $('#pt-ms-summary');
+    if (sel.length === 0) sum.innerHTML = '<span class="pt-ms-placeholder">Any status</span>';
+    else if (sel.length <= 2) sum.innerHTML = '<span class="pt-ms-pills">' + sel.map(statusPill).join('') + '</span>';
+    else sum.innerHTML = '<span class="pt-ms-pills">' + statusPill(sel[0]) + '<span class="pt-ms-more">+' + (sel.length - 1) + ' more</span></span>';
+  }
+
+  /* ---------- filter wiring ---------- */
+  var debounceTimer = null;
+  function onFilterChange(immediate) {
+    st.page = 0;
+    if (immediate) { fetchRows(); return; }
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(fetchRows, 250);
+  }
+
+  function wireFilters() {
+    var map = { 'pt-f-quoteId': 'quoteId', 'pt-f-emailCode': 'emailCode' };
+    Object.keys(map).forEach(function (id) {
+      var el = document.getElementById(id);
+      if (el) el.addEventListener('input', function () { st.filters[map[id]] = el.value; onFilterChange(); });
+    });
+    ['pt-f-channel', 'pt-f-bidType', 'pt-f-user'].forEach(function (id) {
+      var el = document.getElementById(id), key = id.replace('pt-f-', '');
+      if (el) el.addEventListener('change', function () { st.filters[key] = el.value; onFilterChange(true); });
+    });
+    var clear = $('#pt-clear');
+    if (clear) clear.addEventListener('click', function () {
+      st.filters = EMPTY_FILTERS();
+      ['pt-f-quoteId', 'pt-f-emailCode', 'pt-f-channel', 'pt-f-bidType', 'pt-f-user'].forEach(function (id) {
+        var el = document.getElementById(id); if (el) el.value = '';
+      });
+      syncStatusMs();
+      onFilterChange(true);
+    });
+  }
+
+  /* ---------- Quote Summary modal ---------- */
+  var DOC_COLOR = { pdf: '#dc2626', xlsx: '#16a34a', xls: '#16a34a', docx: '#2563eb', doc: '#2563eb' };
+  function docColor(name) { var ext = String(name).split('.').pop().toLowerCase(); return DOC_COLOR[ext] || '#5a6a7e'; }
+
+  function openModal(id) {
+    var b = st.rows.filter(function (r) { return r.id === id; })[0];
+    if (!b) return;
+    st.openId = id;
+
+    $('#qs-modal').innerHTML =
+      '<div class="qs-head"><div class="qs-head-main">'
+      + '<div class="qs-eyebrow"><span class="qs-code">' + esc(b.code) + '</span><span class="qs-eyebrow-sep">·</span>Quote #' + esc(b.id) + '</div>'
+      + '<a class="qs-title qs-title-link" id="qs-title" href="' + CFG.editBase + b.id + '" target="_blank" rel="noopener noreferrer" title="Open quote #' + esc(b.id) + ' in a new tab">'
+      + '<span class="qs-title-num">' + esc(b.id) + '</span>'
+      + '<svg class="qs-title-ext" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>'
+      + '</a>'
+      + '<div class="qs-desc">' + esc(b.name) + '</div></div>'
+      + '<button class="qs-close" id="qs-close" aria-label="Close"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button></div>'
+      + '<div class="qs-body">'
+      + '<div class="qs-amount-row"><div class="qs-amount-block"><div class="qs-amount-label">Total amount</div><div class="qs-amount">' + fmtMoneyFull(b.value) + '</div></div></div>'
+      + '<div id="qs-docs-host"></div>'
+      + '<div class="qs-section"><div class="qs-section-title">Details</div><div class="qs-fields">'
+      + '<div class="qs-field"><span class="qs-field-label">Status</span><span class="qs-field-val">' + statusPill(b.status) + '</span></div>'
+      + '<div class="qs-field"><span class="qs-field-label">Designated User</span><span class="qs-field-val">' + esc(b.user) + '</span></div>'
+      + '<div class="qs-field"><span class="qs-field-label">Channel</span><span class="qs-field-val">' + esc(b.channel) + '</span></div>'
+      + '<div class="qs-field"><span class="qs-field-label">Type of Bid</span><span class="qs-field-val">' + esc(b.bidType) + '</span></div>'
+      + '<div class="qs-field"><span class="qs-field-label">Created</span><span class="qs-field-val">' + esc(b.created) + '</span></div>'
+      + '</div></div></div>'
+      + '<div class="qs-foot">'
+      + '<div class="qs-confirm" id="qs-confirm" hidden><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg> Comment posted</div>'
+      + '<div class="qs-comment">'
+      + '<textarea class="qs-comment-input" id="comment_rfq" rows="1" placeholder="Post a comment… use @ to mention"></textarea>'
+      + '<button class="qs-send" id="qs-send" disabled aria-label="Post comment"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg></button>'
+      + '</div></div>';
+
+    $('#qs-scrim').hidden = false;
+    $('#qs-close').addEventListener('click', closeModal);
+    loadModalDocs(b.id);
+
+    var ta = $('#comment_rfq'), send = $('#qs-send');
+    ta.addEventListener('input', function () { send.disabled = !ta.value.trim(); });
+    send.addEventListener('click', function () { postComment(b.id, ta, send); });
+    ta.addEventListener('keydown', function (e) {
+      // Enter posts, unless the @mention popup is handling it
+      var pop = document.querySelector('.cm-mention-pop');
+      var popOpen = pop && pop.style.display !== 'none';
+      if (e.key === 'Enter' && !e.shiftKey && !popOpen) { e.preventDefault(); if (ta.value.trim()) postComment(b.id, ta, send); }
+    });
+    if (window.MentionAutocomplete) window.MentionAutocomplete.attach(ta);
+    ta.focus();
+  }
+
+  function closeModal() { $('#qs-scrim').hidden = true; $('#qs-modal').innerHTML = ''; st.openId = null; }
+
+  // Real attached documents = the files on disk under documentos/<id>/ (same source as the
+  // quote page), fetched on open. Each row is a download link. NOT rfq.file_document (that's
+  // a checklist field, not the uploaded files).
+  function loadModalDocs(id) {
+    var host = document.getElementById('qs-docs-host');
+    if (!host) return;
+    fetch(CFG.filesUrl + id, { credentials: 'same-origin' })
+      .then(function (r) { return r.json(); })
+      .then(function (res) {
+        if (st.openId !== id) return; // modal changed/closed while loading
+        var files = (res && res.files) || [];
+        files.sort(function (a, b) { return a.toLowerCase().localeCompare(b.toLowerCase()); });
+        if (files.length === 0) { host.innerHTML = ''; return; }
+        host.className = 'qs-section';
+        host.innerHTML = '<div class="qs-section-title">Attached documents <span class="qs-count">' + files.length + '</span></div>'
+          + '<div class="qs-docs">' + files.map(function (f) {
+              var url = CFG.docsBase + id + '/' + encodeURIComponent(f);
+              return '<a class="qs-doc" href="' + url + '" download title="Download ' + esc(f) + '">'
+                + '<span class="qs-doc-ico" style="--dc:' + docColor(f) + '"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg></span>'
+                + '<span class="qs-doc-name">' + esc(f) + '</span>'
+                + '<span class="qs-doc-dl"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg></span>'
+                + '</a>';
+            }).join('') + '</div>';
+      })
+      .catch(function () { if (st.openId === id) host.innerHTML = ''; });
+  }
+
+  function postComment(id, ta, send) {
+    var text = ta.value.trim();
+    if (!text) return;
+    send.disabled = true;
+    var body = new FormData();
+    body.append('guardar_comment', '1');
+    body.append('id_rfq', String(id));
+    body.append('comment_rfq', text);
+    body.append('place', 'quote');
+    // Reuses the exact quote-page comment endpoint: same validation, @mention parsing,
+    // recipient logic and notifications. It redirects on success; we ignore the response.
+    fetch(CFG.commentUrl, { method: 'POST', credentials: 'same-origin', body: body })
+      .then(function () {
+        ta.value = '';
+        var c = $('#qs-confirm'); if (c) { c.hidden = false; setTimeout(function () { if (c) c.hidden = true; }, 2600); }
+      })
+      .catch(function () {})
+      .finally(function () { send.disabled = true; });
+  }
+
+  /* ---------- delegated table clicks ---------- */
+  function wireTable() {
+    $('#pt-tbody').addEventListener('click', function (e) {
+      var open = e.target.closest('[data-open]');
+      if (open) { openModal(parseInt(open.dataset.open, 10)); return; }
+    });
+    $('#pt-pager').addEventListener('click', function (e) {
+      var b = e.target.closest('[data-page]');
+      if (b && !b.disabled) { st.page = parseInt(b.dataset.page, 10); fetchRows(); }
+    });
+    $('#qs-scrim').addEventListener('mousedown', function (e) { if (e.target === $('#qs-scrim')) closeModal(); });
+    document.addEventListener('keydown', function (e) { if (e.key === 'Escape' && !$('#qs-scrim').hidden) closeModal(); });
+  }
+
+  function ensureReady() {
+    if (st.ready) return;
+    st.ready = true;
+    buildStatusMs();
+    syncStatusMs();
+    wireFilters();
+    wireTable();
+  }
+
+  /* ---------- public API (called by pipeline_metrics.js) ---------- */
+  window.PipelineTable = {
+    activate: function (period) {
+      ensureReady();
+      st.period = period;
+      st.page = 0;
+      fetchRows();
+    },
+    setPeriod: function (period) {
+      st.period = period;
+      st.page = 0;
+      fetchRows();
+    }
+  };
+})();

--- a/plantillas/utilities/pipeline_metrics.inc.php
+++ b/plantillas/utilities/pipeline_metrics.inc.php
@@ -3,6 +3,17 @@ if (!ControlSesion::sesion_iniciada()) {
   Redireccion::redirigir1(SERVIDOR);
 }
 $pm_current_year = (int)date('Y');
+
+// Table-view filter dropdowns. Status vocabulary mirrors PipelineMetricsRepository::STATUSES
+// so the table filter always agrees with the charts.
+Conexion::abrir_conexion();
+$pm_conn      = Conexion::obtener_conexion();
+$pm_users     = RepositorioUsuario::getAllActiveUsers($pm_conn);
+usort($pm_users, fn($a, $b) => strcasecmp($a['nombre_usuario'], $b['nombre_usuario']));
+$pm_bid_types = TypeOfBidRepository::get_all($pm_conn);
+$pm_channels  = PipelineTableRepository::getDistinctChannels($pm_conn);
+Conexion::cerrar_conexion();
+$pm_statuses  = PipelineMetricsRepository::STATUSES;
 ?>
 <div class="content-wrapper">
   <section class="content" style="padding-top:18px;padding-bottom:30px;">
@@ -15,6 +26,10 @@ $pm_current_year = (int)date('Y');
           <div class="pm-sub" id="pm-subtitle">Reports · loading…</div>
         </div>
         <div class="pm-head-actions">
+          <div class="pm-seg pm-seg-sm" id="pm-view" role="group" aria-label="Charts or table">
+            <button class="pm-seg-btn is-active" data-view="charts" type="button">Charts</button>
+            <button class="pm-seg-btn" data-view="table" type="button">Table</button>
+          </div>
           <button class="pm-btn" id="pm-export-all" type="button">
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
             Export report
@@ -54,6 +69,7 @@ $pm_current_year = (int)date('Y');
             <button class="pm-seg-btn is-active" data-mode="year" type="button">Year</button>
             <button class="pm-seg-btn" data-mode="quarter" type="button">Quarter</button>
             <button class="pm-seg-btn" data-mode="month" type="button">Month</button>
+            <button class="pm-seg-btn pm-mode-custom" data-mode="custom" type="button" style="display:none;">Custom range</button>
           </div>
 
           <div class="pm-period-divider"></div>
@@ -85,6 +101,12 @@ $pm_current_year = (int)date('Y');
                 <option value="<?= $i + 1; ?>" <?= ((int)date('n') === $i + 1) ? 'selected' : ''; ?>><?= $mn; ?></option>
               <?php endforeach; ?>
             </select>
+          </div>
+
+          <div class="pm-daterange" id="pm-daterange" style="display:none;">
+            <input type="date" class="pm-date" id="pm-date-from" aria-label="From date">
+            <span class="pm-date-sep">to</span>
+            <input type="date" class="pm-date" id="pm-date-to" aria-label="To date">
           </div>
         </div>
 
@@ -140,8 +162,96 @@ $pm_current_year = (int)date('Y');
         <span class="pm-foot-hint">Click any chart segment to see the underlying quotes.</span>
       </div>
       </div><!-- /#pm-charts-body -->
+
+      <!-- table view (hidden until the Table toggle is selected) -->
+      <div id="pm-table-view" hidden>
+        <div class="pt-filters">
+          <div class="pt-filters-grid">
+            <div class="pt-field">
+              <span class="pt-field-label">Quote ID</span>
+              <input class="pt-input" id="pt-f-quoteId" placeholder="e.g. 121438">
+            </div>
+            <div class="pt-field">
+              <span class="pt-field-label">Channel</span>
+              <div class="pt-select-wrap">
+                <select class="pt-input pt-select" id="pt-f-channel">
+                  <option value="">Any channel</option>
+                  <?php foreach ($pm_channels as $ch): ?>
+                    <option value="<?= htmlspecialchars($ch['value']); ?>"><?= htmlspecialchars($ch['label']); ?></option>
+                  <?php endforeach; ?>
+                </select>
+              </div>
+            </div>
+            <div class="pt-field">
+              <span class="pt-field-label">Email Code</span>
+              <input class="pt-input" id="pt-f-emailCode" placeholder="e.g. EM-4471">
+            </div>
+            <div class="pt-field" id="pt-status-field">
+              <span class="pt-field-label">Status</span>
+              <div class="pt-ms-wrap" id="pt-status-ms"><!-- multi-select injected by JS --></div>
+            </div>
+            <div class="pt-field">
+              <span class="pt-field-label">Type of Bid</span>
+              <div class="pt-select-wrap">
+                <select class="pt-input pt-select" id="pt-f-bidType">
+                  <option value="">Any type</option>
+                  <?php foreach ($pm_bid_types as $tb): ?>
+                    <option value="<?= htmlspecialchars($tb->get_type_of_bid()); ?>"><?= htmlspecialchars($tb->get_type_of_bid()); ?></option>
+                  <?php endforeach; ?>
+                </select>
+              </div>
+            </div>
+            <div class="pt-field">
+              <span class="pt-field-label">Designated User</span>
+              <div class="pt-select-wrap">
+                <select class="pt-input pt-select" id="pt-f-user">
+                  <option value="">Any user</option>
+                  <?php foreach ($pm_users as $u): ?>
+                    <option value="<?= (int)$u['id']; ?>"><?= htmlspecialchars($u['nombre_usuario']); ?></option>
+                  <?php endforeach; ?>
+                </select>
+              </div>
+            </div>
+          </div>
+          <div class="pt-filters-foot">
+            <span class="pt-filters-count" id="pt-filters-count">No filters applied</span>
+            <button type="button" class="pt-clear-btn" id="pt-clear" disabled>
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+              Clear filters
+            </button>
+          </div>
+        </div>
+
+        <div class="pt-card">
+          <div class="pt-card-head">
+            <div class="pt-card-title">Quotes</div>
+            <div class="pt-card-sub" id="pt-card-sub">Loading…</div>
+          </div>
+          <div class="pt-table-wrap">
+            <table class="pt-table">
+              <colgroup>
+                <col class="pt-col-id"><col class="pt-col-created"><col class="pt-col-channel"><col class="pt-col-email">
+                <col class="pt-col-status"><col class="pt-col-type"><col class="pt-col-user">
+              </colgroup>
+              <thead>
+                <tr>
+                  <th>Quote ID</th><th>Created</th><th>Channel</th><th>Code</th><th>Status</th>
+                  <th>Type of Bid</th><th>Designated User</th>
+                </tr>
+              </thead>
+              <tbody id="pt-tbody"></tbody>
+            </table>
+          </div>
+          <div id="pt-pager"></div>
+        </div>
+      </div>
     </div>
   </section>
+</div>
+
+<!-- Quote Summary modal (opens on Quote ID click) -->
+<div class="qs-scrim" id="qs-scrim" hidden>
+  <div class="qs-modal" id="qs-modal" role="dialog" aria-modal="true" aria-labelledby="qs-title"></div>
 </div>
 
 <!-- drill-down drawer (fixed to viewport) -->
@@ -168,11 +278,18 @@ $pm_current_year = (int)date('Y');
     dataUrl: '<?= PIPELINE_METRICS_DATA; ?>',
     drillUrl: '<?= PIPELINE_METRICS_DRILLDOWN; ?>',
     exportUrl: '<?= PIPELINE_METRICS_EXPORT; ?>',
+    tableUrl: '<?= PIPELINE_TABLE; ?>',
+    commentUrl: '<?= GUARDAR_COMMENT; ?>',
+    editBase: '<?= EDITAR_COTIZACION; ?>/',
+    filesUrl: '<?= QUOTE_SC; ?>get_quote_files/',
+    docsBase: '<?= DOCS; ?>',
     year: <?= $pm_current_year; ?>,
     month: <?= (int)date('n'); ?>,
     minYear: 2015,
     maxYear: <?= $pm_current_year + 1; ?>
   };
+  window.PM_STATUSES = <?= json_encode($pm_statuses); ?>;
 </script>
 <script src="https://cdn.jsdelivr.net/npm/apexcharts@3.49.1/dist/apexcharts.min.js"></script>
 <script src="<?= asset_url('js/pipeline_metrics.js'); ?>"></script>
+<script src="<?= asset_url('js/pipeline_table.js'); ?>"></script>

--- a/scripts/quote/pipeline_table.php
+++ b/scripts/quote/pipeline_table.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * JSON: one page of the Bid Pipeline Metrics "Table" view.
+ * Params (GET): period (mode=year|quarter|month|custom, year, quarter, month, from, to),
+ *   page, and filters: quoteId, channel, emailCode, statuses[], bidType, user.
+ * Each row carries everything the Quote Summary modal needs (name, value, docs, context).
+ */
+if (!ControlSesion::sesion_iniciada()) {
+  http_response_code(401);
+  echo json_encode(['error' => 'Unauthorized']);
+  exit;
+}
+
+header('Content-Type: application/json');
+
+$mode = $_GET['mode'] ?? 'year';
+$mode = in_array($mode, ['year', 'quarter', 'month', 'custom'], true) ? $mode : 'year';
+
+$period = ['mode' => $mode, 'year' => (int)($_GET['year'] ?? date('Y'))];
+if ($mode === 'quarter') $period['quarter'] = max(1, min(4, (int)($_GET['quarter'] ?? 1)));
+if ($mode === 'month')   $period['month']   = max(1, min(12, (int)($_GET['month'] ?? date('n'))));
+if ($mode === 'custom') {
+  $period['from'] = preg_match('/^\d{4}-\d{2}-\d{2}$/', $_GET['from'] ?? '') ? $_GET['from'] : date('Y-01-01');
+  $period['to']   = preg_match('/^\d{4}-\d{2}-\d{2}$/', $_GET['to'] ?? '')   ? $_GET['to']   : date('Y-12-31');
+}
+
+$statuses = $_GET['statuses'] ?? [];
+if (!is_array($statuses)) $statuses = [$statuses];
+
+$filters = [
+  'quoteId'   => trim((string)($_GET['quoteId'] ?? '')),
+  'channel'   => trim((string)($_GET['channel'] ?? '')),
+  'emailCode' => trim((string)($_GET['emailCode'] ?? '')),
+  'statuses'  => $statuses,
+  'bidType'   => trim((string)($_GET['bidType'] ?? '')),
+  'user'      => trim((string)($_GET['user'] ?? '')),
+];
+$page = max(0, (int)($_GET['page'] ?? 0));
+
+try {
+  Conexion::abrir_conexion();
+  $conexion = Conexion::obtener_conexion();
+  $result = PipelineTableRepository::getPage($conexion, $period, $filters, $page);
+  Conexion::cerrar_conexion();
+  echo json_encode($result);
+} catch (Exception $e) {
+  http_response_code(500);
+  error_log('Pipeline table error: ' . $e->getMessage());
+  echo json_encode(['error' => 'Failed to load quotes']);
+}

--- a/tests/php/pipeline_table_test.php
+++ b/tests/php/pipeline_table_test.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Integration test for PipelineTableRepository (Bid Pipeline Metrics "Table" view).
+ *
+ * Covers period scoping, status filter, designated-user filter, and custom date range
+ * (including an inverted range returning empty, no error) over the same rfq.created_at
+ * cohort the charts use.
+ *
+ * Transaction-isolated (ROLLBACK). Rows live in year 2099 so the period filter matches
+ * only what this test inserts (real rows carry a different/NULL created_at).
+ * Run:  docker exec lamp-php84 php /var/www/html/rfq/tests/php/pipeline_table_test.php
+ */
+
+$root = __DIR__ . '/../../';
+require_once $root . 'app/Bootstrap/config.inc.php';
+require_once $root . 'app/Bootstrap/routes.inc.php';
+require_once $root . 'app/Bootstrap/Conexion.inc.php';
+require_once $root . 'app/Report/PipelineMetricsRepository.inc.php';
+require_once $root . 'app/Report/PipelineTableRepository.inc.php';
+
+$pass = 0; $fail = 0;
+function check($label, $expected, $actual) {
+  global $pass, $fail;
+  $ok = $expected === $actual;
+  if ($ok) { $pass++; echo "  PASS  $label\n"; }
+  else     { $fail++; echo "  FAIL  $label — expected " . var_export($expected, true) . ", got " . var_export($actual, true) . "\n"; }
+}
+
+Conexion::abrir_conexion();
+$c = Conexion::obtener_conexion();
+$c->beginTransaction();
+
+try {
+  // --- test users (designated) ---
+  $mkUser = function ($name) use ($c) {
+    $stmt = $c->prepare("INSERT INTO usuarios (nombre_usuario, password, nombres, apellidos, cargo, email, status, notif_inapp, notif_email)
+                         VALUES (:u, 'x', :n, 'Test', '3', :e, 1, 1, 0)");
+    $stmt->execute([':u' => $name, ':n' => $name, ':e' => $name . '@test.local']);
+    return (int)$c->lastInsertId();
+  };
+  $userA = $mkUser('pt_a_' . uniqid());
+  $userB = $mkUser('pt_b_' . uniqid());
+
+  // --- three quotes in 2099 with distinct derived statuses ---
+  $mkRfq = function ($fields) use ($c) {
+    $cols = array_merge([
+      'id_usuario' => 1, 'usuario_designado' => 1, 'canal' => 'FedBid', 'email_code' => 'PT-TEST',
+      'type_of_bid' => 'IT', 'status' => 0, 'completado' => 0, 'comments' => '', 'award' => 0,
+      'total_price' => 1000, 'deleted' => 0, 'name' => 'Pipeline table test quote', 'file_document' => 'a.pdf|b.xlsx',
+      'created_at' => '2099-06-15 10:00:00',
+    ], $fields);
+    $keys = array_keys($cols);
+    $sql = 'INSERT INTO rfq (' . implode(',', $keys) . ') VALUES (:' . implode(',:', $keys) . ')';
+    $stmt = $c->prepare($sql);
+    foreach ($cols as $k => $v) $stmt->bindValue(':' . $k, $v);
+    $stmt->execute();
+    return (int)$c->lastInsertId();
+  };
+  $qBid       = $mkRfq(['completado' => 1]);                       // 'bid'
+  $qSubmitted = $mkRfq(['completado' => 1, 'status' => 1]);        // 'submitted'
+  $qAward     = $mkRfq(['completado' => 1, 'award' => 1, 'usuario_designado' => $userB]); // 'award'
+
+  $year = ['mode' => 'year', 'year' => 2099];
+  $noF  = ['quoteId' => '', 'channel' => '', 'emailCode' => '', 'statuses' => [], 'bidType' => '', 'user' => ''];
+
+  $all = PipelineTableRepository::getPage($c, $year, $noF, 0);
+  check('table: 3 quotes in 2099', 3, $all['total']);
+
+  $byId = [];
+  foreach ($all['rows'] as $r) $byId[$r['id']] = $r;
+  check('row carries created date', true, (bool)preg_match('#^\d{2}/\d{2}/\d{4}$#', $byId[$qBid]['created']));
+  check('row status label present', 'Award', $byId[$qAward]['statusLabel']);
+  check('row has no watched field (Quote Watchers removed)', false, isset($byId[$qBid]['watched']));
+
+  // status filter
+  $awardOnly = PipelineTableRepository::getPage($c, $year, array_merge($noF, ['statuses' => ['award']]), 0);
+  check('status filter award -> 1', 1, $awardOnly['total']);
+
+  // designated-user filter (qAward is assigned to userB)
+  $userFilter = PipelineTableRepository::getPage($c, $year, array_merge($noF, ['user' => $userB]), 0);
+  check('designated-user filter -> 1', 1, $userFilter['total']);
+
+  // custom range covering June 2099
+  $custom = PipelineTableRepository::getPage($c, ['mode' => 'custom', 'from' => '2099-01-01', 'to' => '2099-12-31'], $noF, 0);
+  check('custom range covering the rows -> 3', 3, $custom['total']);
+  // inverted range -> empty, no error
+  $inverted = PipelineTableRepository::getPage($c, ['mode' => 'custom', 'from' => '2099-12-31', 'to' => '2099-01-01'], $noF, 0);
+  check('inverted custom range -> 0', 0, $inverted['total']);
+
+  // distinct channels helper (used by the Channel filter dropdown)
+  $channels = PipelineTableRepository::getDistinctChannels($c);
+  $values = array_column($channels, 'value');
+  check('distinct channels includes our test channel', true, in_array('FedBid', $values, true));
+
+} finally {
+  $c->rollBack();
+  Conexion::cerrar_conexion();
+}
+
+echo "\n$pass passed, $fail failed\n";
+exit($fail === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary
Miscommunication on scope during the previous removal PR (#71): "Pipeline Table View + Quote Watchers Removal" was understood to mean dropping a DB table, not removing the Bid Pipeline Metrics Charts|Table toggle/UI. This PR restores the Table View while keeping Quote Watchers itself gone:

**Restored (from before #71):**
- `#pm-view` Charts|Table toggle, `#pm-table-view` filterable/paginated quote table, Quote Summary modal
- `app/Report/PipelineTableRepository.inc.php`, `scripts/quote/pipeline_table.php`, `js/pipeline_table.js`
- `PIPELINE_TABLE` route + `index.php` dispatch/autoload
- `pt-*`/`qs-*` CSS block, custom date-range period mode, `js/pipeline_metrics.js` toggle logic

**Stays removed (Quote Watchers):**
- No watch button/column, no `quote_watchers` table, no notification fan-out
- `PipelineTableRepository::getPage()` no longer LEFT JOINs `quote_watchers` or returns a `watched` field; dropped the now-unused `$currentUserId` param
- `js/pipeline_table.js` has no `toggleWatch`/`reflectWatch`/watch click handling (confirmed pre-existing: no Watch button/column markup was ever actually rendered by this file, so nothing user-visible changes here)

**Not needed:** no new/reverted DB migrations — Table View reads existing `rfq`/`usuarios` tables, `quote_watchers` was never required for it.

## Test plan
- [x] `tests/php/pipeline_table_test.php` (new, replaces the watched-flag assertions from the deleted `quote_watchers_test.php`) — 9/9
- [x] Full PHP suite (`tests/php/*.php`) — all green
- [x] Full JS unit suite — all green
- [x] `tests/specs/09-pipeline-metrics.spec.js` — 9/9, no regressions
- [x] Manual Playwright smoke test clicking the restored Table toggle: 25 rows render, opening a row's Quote Summary modal works, zero console errors