### PR TITLE
Fix Download All button (tmp/zips/ never created)

### DIFF
--- a/scripts/utilities/download_all.php
+++ b/scripts/utilities/download_all.php
@@ -22,7 +22,14 @@ try {
 
   // Define the ZIP file name and path
   $zipFileName = 'files_' . $idRfq . '.zip';
-  $zipFilePath = $_SERVER['DOCUMENT_ROOT'] . '/rfq/tmp/zips/' . $zipFileName; // Path where the ZIP file will be saved
+  $zipDir = $_SERVER['DOCUMENT_ROOT'] . '/rfq/tmp/zips';
+  $zipFilePath = $zipDir . '/' . $zipFileName; // Path where the ZIP file will be saved
+
+  // ZipArchive::open() with CREATE does not create missing parent directories, and tmp/ is
+  // gitignored runtime-only content — nothing else ever creates the zips/ subfolder.
+  if (!is_dir($zipDir)) {
+    mkdir($zipDir, 0777, true);
+  }
 
   $zip = new ZipArchive();
 

--- a/tests/specs/12-documents-drawer.spec.js
+++ b/tests/specs/12-documents-drawer.spec.js
@@ -77,6 +77,23 @@ test.describe('Documents Drawer Tab', () => {
     await expect(page.locator('.doc-file-row', { hasText: 'to-delete.pdf' })).toHaveCount(0);
     expect(page.url()).toContain(`editar_cotizacion/${rfqId}`);
   });
+
+  test('Download All zips the attached files and returns a working download URL', async ({ page, request }) => {
+    await page.click('#qed-open-documents');
+    await page.setInputFiles('#qed-documents-widget .doc-dropzone input[type=file]', uploadFile('zip-me.pdf'));
+    await page.waitForSelector('[data-testid="doc-file-delete"]');
+
+    const [response] = await Promise.all([
+      page.waitForResponse((res) => res.url().includes('/quote/download_all')),
+      page.click('#qed-download-all-btn'),
+    ]);
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.downloadUrl).toMatch(new RegExp(`^/rfq/tmp/zips/files_${rfqId}\\.zip$`));
+
+    const zipRes = await request.get('http://localhost' + body.downloadUrl);
+    expect(zipRes.ok()).toBe(true);
+  });
 });
 
 test.describe('Documents widget on the New Quote page (deferred mode)', () => {


### PR DESCRIPTION
## Summary
- `download_all.php` builds a zip at `tmp/zips/files_{id}.zip`, but nothing ever creates the `zips/` subfolder — `tmp/` is gitignored runtime-only content, and `ZipArchive::open(..., CREATE)` does not create missing parent directories.
- On any environment without that directory already present, `ZipArchive::close()` silently failed to write the file, and the resulting PHP warning was emitted as HTML *before* the JSON response — breaking the client's `res.json()` parse. This predates the Documents drawer rework; the old bootstrap-fileinput-driven Download All button was equally broken.
- Fix: `mkdir($zipDir, 0777, true)` before opening the archive, same pattern already used in `Input::save_files()`.

## Test plan
- [x] New Playwright test: uploads a file, clicks Download All, asserts a clean JSON response (`downloadUrl`) and that the zip actually downloads (200) — `tests/specs/12-documents-drawer.spec.js`
- [x] Full Documents Drawer spec (8 tests) passing
- [x] `tests/php/documents_drawer_test.php` (13 checks) still passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)