### PR TITLE
fix: allow Commercial Moving quotes to add service items

### DIFF
--- a/app/Quote/Rfq.inc.php
+++ b/app/Quote/Rfq.inc.php
@@ -473,11 +473,12 @@ class Rfq {
 
   public function isServices() {
     // Keep in step with SYNCABLE_BID_TYPES in plantillas/quote/nueva_cotizacion.inc.php.
-    // The sync list plus the two legacy service-eligible types (Computers, Back Up Batteries).
+    // The sync list plus the legacy service-eligible types (Computers, Back Up Batteries,
+    // Commercial Moving).
     $services = [
       'Services', 'Audio Visual', 'Computers', 'Back Up Batteries',
       'MOVING & LOGISTICS', 'PROFESSIONAL SERVICES', 'IT',
-      'A/V', 'A/V - INSTALLATION', 'A/V - SERVICES'
+      'A/V', 'A/V - INSTALLATION', 'A/V - SERVICES', 'Commercial Moving'
     ];
     if (in_array($this->type_of_bid, $services)) {
       return true;

--- a/tests/php/commercial_moving_test.php
+++ b/tests/php/commercial_moving_test.php
@@ -20,6 +20,7 @@ require_once $root . 'app/Service/Service.inc.php';
 require_once $root . 'app/Utilities/ProposalRepository.inc.php';
 require_once $root . 'app/TypeOfBid/TypeOfBid.inc.php';
 require_once $root . 'app/TypeOfBid/TypeOfBidRepository.inc.php';
+require_once $root . 'app/Quote/Rfq.inc.php';
 
 $SPLIT = '50% Upfront / 50% on Completion';
 
@@ -58,6 +59,10 @@ $cc_html     = ProposalRepository::print_service('Net 30/CC', $service, 1);
 check('50/50 service output equals Net 30 (×1, no uplift)', $net30_html, $split_html);
 check('50/50 service keeps base unit price $150.00', true, strpos($split_html, '$ 150.00') !== false);
 check('Net 30/CC service applies ×1.03 uplift ($154.50)', true, strpos($cc_html, '$ 154.50') !== false);
+
+/* ---------- Commercial Moving quotes are allowed to have Service items ---------- */
+$commercial_moving_rfq = new Rfq(['type_of_bid' => 'Commercial Moving']);
+check('isServices() true for Commercial Moving', true, $commercial_moving_rfq->isServices());
 
 /* ---------- Commercial Moving bid type surfaces in the dropdown ---------- */
 Conexion::abrir_conexion();


### PR DESCRIPTION
## Summary
- `Rfq::isServices()` gates the Services section (Add Service button + table) by a hardcoded bid-type allowlist that was never updated when the `Commercial Moving` bid type was added, so those quotes couldn't have service line items.
- Added `Commercial Moving` to the allowlist in `app/Quote/Rfq.inc.php`.

## Test plan
- [x] Added `isServices() true for Commercial Moving` to `tests/php/commercial_moving_test.php`, confirmed it failed against the original code, then passed after the fix.
- [x] Re-ran `pipeline_metrics_test.php`, `pipeline_table_test.php`, `advanced_search_test.php`, `annual_awards_test.php` (all touch bid-type/services logic) — all still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)