### PR TITLE
Add Internal Due Date filter and Status by User chart to Pipeline Metrics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 All built. Detail for most of these lives in the matching `###` section below.
 
-Quote Inline Editing · SharePoint Sheet Sync · Comment Mentions & Notifications · Bid Requirement Fields (Site Visit/Q&A Deadline/Resumes) · Bid Pipeline Sync Controls · Bid Pipeline Metrics Dashboard · Pipeline Table View · 3-Year Annual Awards Comparison · Quote Lifecycle Audit Events · Write-Once Sheet Sync · Advanced Quote Search · Commercial Moving bid type + 50/50 payment term · Shared Notification Mailbox · Daily RFQ Digest Email · Quote Checklist & Info Drawer · Documents Drawer Tab + Custom File Widget · Import Items Enhancements (template download, append/replace mode, provider import) · Items & Services Table Redesign
+Quote Inline Editing · SharePoint Sheet Sync · Comment Mentions & Notifications · Bid Requirement Fields (Site Visit/Q&A Deadline/Resumes) · Bid Pipeline Sync Controls · Bid Pipeline Metrics Dashboard · Pipeline Table View · 3-Year Annual Awards Comparison · Quote Lifecycle Audit Events · Write-Once Sheet Sync · Advanced Quote Search · Commercial Moving bid type + 50/50 payment term · Shared Notification Mailbox · Daily RFQ Digest Email · Quote Checklist & Info Drawer · Documents Drawer Tab + Custom File Widget · Import Items Enhancements (template download, append/replace mode, provider import) · Items & Services Table Redesign · Internal Due Date Table Filter + Required Field · Pipeline Status by User + Wider Drill-down Drawer
 
 ## Environment
 
@@ -79,11 +79,15 @@ Endpoint `POST quote/load_unified_audit_trail` queries all three (re-quote joine
 
 Two listing pages mirror this: Sources Sought (`quote/sources_sought`) and No Award (`quote/no_award`, with a Reason column). Tests: `tests/php/pipeline_metrics_test.php`, `tests/specs/09-pipeline-metrics.spec.js`.
 
+**Status by user** — full-width card directly under Status Distribution: one horizontal stacked bar per designated user with ≥1 quote in the period (10-bucket colors, alphabetical, `PipelineMetricsRepository::getStatusByUser()` — INNER JOIN to `usuarios` so a dangling/unassigned `usuario_designado` naturally drops out, no LEFT JOIN needed since the column is `NOT NULL`). Percent mode uses ApexCharts native `stackType:'100%'` (per-user-normalized). Drill-down spec type `byUser` (`user` + `key`) needs `usuario_designado` added to `getDrillDown()`'s *inner* subquery SELECT list only — the outer SELECT/columns stay unchanged, WHERE can reference any inner-subquery column. Export sheet added the same way as the other chart keys. `.pm-drawer` is `50vw` (was a fixed `430px`) for every drill-down on the page, not just this chart.
+
 ### Pipeline Table View
 
 `Charts | Table` toggle on `perfil/reports/pipeline_metrics` (`#pm-view`) swaps to a filterable, server-paginated (25/row) quote table over the same `created_at` cohort as the charts (`PipelineTableRepository`, `js/pipeline_table.js`). Clicking a row opens a Quote Summary modal (real attached files from `quote/get_quote_files/<id>`, not the `rfq.file_document` checklist field; quick-comment reuses `#comment_rfq`/`mentions.js`).
 
 **No Quote Watchers** — that subsystem (per-quote watch subscriptions + notification fan-out) was built alongside this Table View, then removed; don't reintroduce a `watched` field/join without deliberately re-adding that whole feature. Test: `tests/php/pipeline_table_test.php`.
+
+**Internal Due Date filter** — 7th filter field (after Designated User), preset dropdown only (Today/Tomorrow/Next 7 days/Overdue), purely date-based via MySQL `CURDATE()` in `PipelineTableRepository::dueDateClause()` — no status-aware "exclude Awarded" logic, no custom range. AND-combines with every other filter and the period exactly like the rest. Also **required now everywhere it's entered**: New Quote form (`required` + `ValidadorCotizacionRegistro`/`ValidadorCotizacion::validar_internal_due_date()`, same "Must be fill out." pattern as End Date, no cross-field constraint) and the Information drawer tab (`save_information.php` rejects a blank value pre-DB-write, surfaced through the drawer's existing error banner — no new client-side validation). Tests: `tests/php/pipeline_table_test.php`, `tests/php/internal_due_date_test.php`.
 
 ### Charts Tab — Annual Awards (3-year)
 

--- a/app/Quote/ValidadorCotizacion.inc.php
+++ b/app/Quote/ValidadorCotizacion.inc.php
@@ -5,12 +5,14 @@ abstract class ValidadorCotizacion {
   protected $email_code;
   protected $issue_date;
   protected $end_date;
+  protected $internal_due_date;
   protected $usuario_designado;
   protected $type_of_bid;
   protected $canal;
   protected $error_email_code;
   protected $error_issue_date;
   protected $error_end_date;
+  protected $error_internal_due_date;
 
   public function __construct() {
 
@@ -54,6 +56,15 @@ abstract class ValidadorCotizacion {
     return '';
   }
 
+  protected function validar_internal_due_date($internal_due_date) {
+    if (!$this->variable_iniciada($internal_due_date)) {
+      return 'Must be fill out.';
+    } else {
+      $this->internal_due_date = $internal_due_date;
+    }
+    return '';
+  }
+
   public function obtener_email_code() {
     return $this->email_code;
   }
@@ -64,6 +75,10 @@ abstract class ValidadorCotizacion {
 
   public function obtener_end_date() {
     return $this->end_date;
+  }
+
+  public function obtener_internal_due_date() {
+    return $this->internal_due_date;
   }
 
   public function obtener_usuario_designado() {
@@ -90,6 +105,10 @@ abstract class ValidadorCotizacion {
     return $this->error_end_date;
   }
 
+  public function obtener_error_internal_due_date() {
+    return $this->error_internal_due_date;
+  }
+
   public function mostrar_email_code() {
     if ($this->email_code != '') {
       echo 'value="' . $this->email_code . '"';
@@ -105,6 +124,12 @@ abstract class ValidadorCotizacion {
   public function mostrar_end_date() {
     if ($this->end_date != '') {
       echo 'value="' . $this->end_date . '"';
+    }
+  }
+
+  public function mostrar_internal_due_date() {
+    if ($this->internal_due_date != '') {
+      echo 'value="' . $this->internal_due_date . '"';
     }
   }
 
@@ -126,8 +151,15 @@ abstract class ValidadorCotizacion {
     }
   }
 
+  public function mostrar_error_internal_due_date() {
+    if ($this->error_internal_due_date != '') {
+      echo $this->aviso_inicio . $this->error_internal_due_date . $this->aviso_cierre;
+    }
+  }
+
   public function registro_cotizacion_valida() {
-    if ($this->error_email_code == '' && $this->error_issue_date == '' && $this->error_end_date == '') {
+    if ($this->error_email_code == '' && $this->error_issue_date == '' && $this->error_end_date == ''
+      && $this->error_internal_due_date == '') {
       return true;
     } else {
       return false;

--- a/app/Quote/ValidadorCotizacionRegistro.inc.php
+++ b/app/Quote/ValidadorCotizacionRegistro.inc.php
@@ -1,12 +1,13 @@
 <?php
 class ValidadorCotizacionRegistro extends ValidadorCotizacion{
-  public function __construct($conexion, $email_code, $issue_date, $end_date, $type_of_bid, $usuario_designado, $canal){
+  public function __construct($conexion, $email_code, $issue_date, $end_date, $internal_due_date, $type_of_bid, $usuario_designado, $canal){
     $this->aviso_inicio = "<label class='text-danger' role='alert'>";
     $this->aviso_cierre = "</label>";
 
     $this-> email_code = '';
     $this-> issue_date = '';
     $this-> end_date = '';
+    $this-> internal_due_date = '';
     $this-> type_of_bid = $type_of_bid;
     $this-> usuario_designado = $usuario_designado;
     $this-> canal = $canal;
@@ -14,6 +15,7 @@ class ValidadorCotizacionRegistro extends ValidadorCotizacion{
     $this-> error_email_code = $this-> validar_email_code($conexion, $email_code);
     $this-> error_issue_date = $this-> validar_issue_date($issue_date);
     $this-> error_end_date = $this-> validar_end_date($end_date);
+    $this-> error_internal_due_date = $this-> validar_internal_due_date($internal_due_date);
   }
 }
 ?>

--- a/app/Report/PipelineMetricsRepository.inc.php
+++ b/app/Report/PipelineMetricsRepository.inc.php
@@ -192,7 +192,44 @@ class PipelineMetricsRepository {
       'awardsByCategory'    => self::categoryBreakdown($conexion, $period, 'awards'),
       'submittedByCategory' => self::categoryBreakdown($conexion, $period, 'submitted'),
       'pricing'             => self::pricingEffort($conexion, $period),
+      'byUser'              => self::getStatusByUser($conexion, $period),
     ];
+  }
+
+  /**
+   * Status-bucket breakdown per designated user, for the "Status by user" chart.
+   * Excludes quotes with no designated user; only users with >=1 matching quote are
+   * returned (no zero-count rows), ordered alphabetically by name. Every row's `counts`
+   * has all 10 status keys present (zero-filled).
+   */
+  public static function getStatusByUser($conexion, array $period) {
+    [$periodSql, $params] = self::periodClause($period);
+
+    $sql = "SELECT u.id AS user_id, u.nombre_usuario AS user_name, t.bucket AS bucket, COUNT(*) AS cnt
+            FROM (
+              SELECT rfq.usuario_designado, " . self::STATUS_CASE . " AS bucket
+              FROM rfq
+              WHERE rfq.deleted = 0 AND rfq.usuario_designado IS NOT NULL AND $periodSql
+            ) t
+            JOIN usuarios u ON u.id = t.usuario_designado
+            GROUP BY u.id, u.nombre_usuario, t.bucket";
+    $rows = self::run($conexion, $sql, $params);
+
+    $byUser = [];
+    foreach ($rows as $r) {
+      $uid = (int)$r['user_id'];
+      if (!isset($byUser[$uid])) {
+        $counts = [];
+        foreach (self::STATUSES as $s) { $counts[$s['key']] = 0; }
+        $byUser[$uid] = ['userId' => $uid, 'userName' => $r['user_name'], 'total' => 0, 'counts' => $counts];
+      }
+      $byUser[$uid]['counts'][$r['bucket']] = (int)$r['cnt'];
+      $byUser[$uid]['total'] += (int)$r['cnt'];
+    }
+
+    $result = array_values($byUser);
+    usort($result, fn($a, $b) => strcasecmp($a['userName'], $b['userName']));
+    return $result;
   }
 
   /**
@@ -265,7 +302,7 @@ class PipelineMetricsRepository {
 
     $sql = "SELECT id, email_code, name, type_of_bid, total_price, issue_date, bucket
             FROM (
-              SELECT rfq.id, rfq.email_code, rfq.name, rfq.type_of_bid,
+              SELECT rfq.id, rfq.email_code, rfq.name, rfq.type_of_bid, rfq.usuario_designado,
                      " . self::VALUE_EXPR . " AS total_price, rfq.issue_date, rfq.completado,
                      " . self::STATUS_CASE . " AS bucket
               FROM rfq" . self::SERVICES_JOIN . "
@@ -322,6 +359,13 @@ class PipelineMetricsRepository {
       if ($key === 'not_submitted') return "completado = 1 AND bucket = 'not_submitted'";
       if ($key === 'no_bid')        return "completado = 1 AND bucket = 'no_bid'";
       return null;
+    }
+    if ($type === 'byUser') {
+      $key = $spec['key'] ?? '';
+      if (!in_array($key, $validKeys, true)) return null;
+      $params[':dkey']  = $key;
+      $params[':duser'] = (int)($spec['user'] ?? 0);
+      return "bucket = :dkey AND usuario_designado = :duser";
     }
     return null;
   }

--- a/app/Report/PipelineTableRepository.inc.php
+++ b/app/Report/PipelineTableRepository.inc.php
@@ -116,6 +116,10 @@ class PipelineTableRepository {
       $params[':uid'] = (int)$filters['user'];
       $inner[] = "rfq.usuario_designado = :uid";
     }
+    if (!empty($filters['dueDate'])) {
+      $clause = self::dueDateClause($filters['dueDate']);
+      if ($clause !== null) $inner[] = $clause;
+    }
 
     $statusWhere = '';
     if (!empty($filters['statuses']) && is_array($filters['statuses'])) {
@@ -129,6 +133,17 @@ class PipelineTableRepository {
     }
 
     return [implode(' AND ', $inner), $statusWhere, $params];
+  }
+
+  /** Internal Due Date preset WHERE fragment, purely date-based (server CURDATE()). */
+  private static function dueDateClause($preset) {
+    switch ($preset) {
+      case 'today':    return "DATE(rfq.internal_due_date) = CURDATE()";
+      case 'tomorrow': return "DATE(rfq.internal_due_date) = CURDATE() + INTERVAL 1 DAY";
+      case 'week':     return "DATE(rfq.internal_due_date) BETWEEN CURDATE() AND CURDATE() + INTERVAL 7 DAY";
+      case 'overdue':  return "DATE(rfq.internal_due_date) < CURDATE()";
+      default:         return null;
+    }
   }
 
   /** Period WHERE fragment on rfq.created_at. Adds a custom from/to range for the table. */

--- a/css/estilos.css
+++ b/css/estilos.css
@@ -3092,7 +3092,7 @@ h3.text-info.text-center .fa-exclamation-circle {
 }
 .pm-drawer-scrim.is-open { opacity: 1; pointer-events: auto; }
 .pm-drawer {
-  position: fixed; top: 0; right: 0; bottom: 0; width: 430px; max-width: 92%;
+  position: fixed; top: 0; right: 0; bottom: 0; width: 50vw; max-width: 92%;
   background: #fff; border-left: 1px solid var(--pm-line); box-shadow: -16px 0 40px rgba(15,22,35,0.18);
   transform: translateX(100%); transition: transform 0.32s cubic-bezier(0.22,1,0.36,1);
   z-index: 1091; display: flex; flex-direction: column;
@@ -3357,7 +3357,7 @@ input.sq-input[type="date"] { font-size: 12.5px; color: #2c3849; }
   margin-top: 16px; background: white; border: 1px solid var(--line); border-radius: var(--radius);
   padding: 14px 16px 12px; box-shadow: 0 1px 2px rgba(15,22,35,0.03);
 }
-.pt-filters-grid { display: grid; grid-template-columns: repeat(6, 1fr); gap: 12px; }
+.pt-filters-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 12px; }
 .pt-field { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
 .pt-field-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; font-weight: 700; color: var(--ink-700); }
 .pt-input {

--- a/forms/quote/registro_cotizacion_vacio.inc.php
+++ b/forms/quote/registro_cotizacion_vacio.inc.php
@@ -71,7 +71,7 @@
     <div class="col-md-6">
       <div class="form-group">
         <label for="internal_due_date">Internal Due Date</label>
-        <input type="text" class="date form-control" id="internal_due_date" name="internal_due_date" placeholder="MM/DD/YYYY">
+        <input type="text" class="date form-control" id="internal_due_date" name="internal_due_date" placeholder="MM/DD/YYYY" required>
         <small class="form-text text-muted"><i class="fas fa-table mr-1" style="color:#2db4e8;"></i>Synced to the SharePoint sheet.</small>
       </div>
     </div>

--- a/forms/quote/registro_cotizacion_validado.inc.php
+++ b/forms/quote/registro_cotizacion_validado.inc.php
@@ -78,8 +78,9 @@
       <div class="form-group">
         <label for="internal_due_date">Internal Due Date</label>
         <input type="text" class="date form-control" id="internal_due_date" name="internal_due_date"
-               placeholder="MM/DD/YYYY" value="<?= htmlspecialchars($_POST['internal_due_date'] ?? '', ENT_QUOTES, 'UTF-8'); ?>">
+               placeholder="MM/DD/YYYY" required <?php $validador->mostrar_internal_due_date(); ?>>
         <small class="form-text text-muted"><i class="fas fa-table mr-1" style="color:#2db4e8;"></i>Synced to the SharePoint sheet.</small>
+        <?php $validador->mostrar_error_internal_due_date(); ?>
       </div>
     </div>
   </div>

--- a/js/pipeline_metrics.js
+++ b/js/pipeline_metrics.js
@@ -15,6 +15,7 @@
 
   var APEX_FONT = "'Manrope', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif";
   var INK_500 = '#5a6a7e', INK_400 = '#7d8ba0', LINE = '#e3e7ee';
+  var PM_STATUSES = window.PM_STATUSES || [];
   var MONTHS = ['January','February','March','April','May','June','July','August','September','October','November','December'];
   var animCfg = { enabled: true, easing: 'easeinout', speed: 520, animateGradually: { enabled: true, delay: 90 } };
   var noToolbar = { show: false };
@@ -100,6 +101,7 @@
     $('#pm-subtitle').textContent = 'Reports · ' + periodLabel() + ' · ' + d.count + (d.count === 1 ? ' bid' : ' bids') + ' in pipeline';
     renderKpis(d);
     renderStatus(d);
+    renderByUser(d);
     renderWinLoss(d);
     renderCategory('awards', d.awardsByCategory, d);
     renderCategory('submitted', d.submittedByCategory, d);
@@ -201,6 +203,51 @@
         var tot = cur.reduce(function (a, b) { return a + b.count; }, 0);
         var pct = tot ? Math.round(it.count / tot * 100) : 0;
         return tip(it.color, it.label, state.show === 'percent' ? pct + '% · ' + it.count + ' bids' : it.count + ' bids · ' + pct + '%');
+      } },
+      states: { active: { filter: { type: 'darken', value: 0.85 } } }
+    });
+  }
+
+  /* ================= chart 1b: status by user (horizontal stacked bar) ================= */
+  function renderByUser(d) {
+    var rows = d.byUser || [];
+    if (d.empty || rows.length === 0) { setEmpty('byUser', true); return; }
+    setEmpty('byUser', false);
+    setHint('byUser', rows.length + (rows.length === 1 ? ' designated user' : ' designated users'));
+    var asPct = state.show === 'percent';
+    var height = Math.max(300, 130 + rows.length * 48);
+    mountOrUpdate('byUser', {
+      chart: {
+        type: 'bar', height: height, stacked: true, stackType: asPct ? '100%' : 'normal',
+        fontFamily: APEX_FONT, animations: animCfg, toolbar: noToolbar,
+        events: { dataPointSelection: function (e, ctx, cf) {
+          var cur = state.data.byUser || [];
+          var user = cur[cf.dataPointIndex];
+          var status = PM_STATUSES[cf.seriesIndex];
+          var n = user ? (user.counts[status.key] || 0) : 0;
+          if (user && status && n > 0) openDrill(
+            { type: 'byUser', user: user.userId, key: status.key },
+            user.userName + ' · ' + status.label, status.color);
+        } }
+      },
+      series: PM_STATUSES.map(function (s) {
+        return { name: s.label, data: rows.map(function (u) { return u.counts[s.key] || 0; }) };
+      }),
+      colors: PM_STATUSES.map(function (s) { return s.color; }),
+      plotOptions: { bar: { horizontal: true, borderRadius: 3, barHeight: '62%' } },
+      dataLabels: { enabled: false },
+      legend: { position: 'bottom', fontSize: '12px', labels: { colors: INK_500 }, markers: { width: 9, height: 9, radius: 3 }, itemMargin: { horizontal: 10, vertical: 4 } },
+      grid: { borderColor: LINE, strokeDashArray: 4, padding: { left: 8, right: 8 } },
+      xaxis: { categories: rows.map(function (u) { return u.userName; }),
+        labels: { style: { fontSize: '11px', colors: INK_400 }, formatter: function (v) { return asPct ? Math.round(v) + '%' : Math.round(v); } },
+        axisBorder: { color: LINE }, axisTicks: { color: LINE } },
+      yaxis: { labels: { style: { fontSize: '12px', colors: INK_500, fontWeight: 600 } } },
+      tooltip: { custom: function (o) {
+        var row = (state.data.byUser || [])[o.dataPointIndex];
+        var status = PM_STATUSES[o.seriesIndex];
+        var n = row ? (row.counts[status.key] || 0) : 0;
+        var pct = row && row.total ? Math.round(n / row.total * 100) : 0;
+        return tip(status.color, status.label, n + (n === 1 ? ' quote' : ' quotes') + ' · ' + pct + '%');
       } },
       states: { active: { filter: { type: 'darken', value: 0.85 } } }
     });

--- a/js/pipeline_table.js
+++ b/js/pipeline_table.js
@@ -17,7 +17,7 @@
   var STATUS_BY_KEY = {};
   STATUSES.forEach(function (s) { STATUS_BY_KEY[s.key] = s; });
 
-  var EMPTY_FILTERS = function () { return { quoteId: '', channel: '', emailCode: '', statuses: [], bidType: '', user: '' }; };
+  var EMPTY_FILTERS = function () { return { quoteId: '', channel: '', emailCode: '', statuses: [], bidType: '', user: '', dueDate: '' }; };
 
   var st = {
     period: null,
@@ -52,6 +52,7 @@
     if (f.statuses.length) n++;
     if (f.bidType) n++;
     if (f.user) n++;
+    if (f.dueDate) n++;
     return n;
   }
 
@@ -65,6 +66,7 @@
     if (f.emailCode.trim()) q.push('emailCode=' + encodeURIComponent(f.emailCode.trim()));
     if (f.bidType) q.push('bidType=' + encodeURIComponent(f.bidType));
     if (f.user) q.push('user=' + encodeURIComponent(f.user));
+    if (f.dueDate) q.push('dueDate=' + encodeURIComponent(f.dueDate));
     f.statuses.forEach(function (k) { q.push('statuses[]=' + encodeURIComponent(k)); });
     return q.join('&');
   }
@@ -213,14 +215,14 @@
       var el = document.getElementById(id);
       if (el) el.addEventListener('input', function () { st.filters[map[id]] = el.value; onFilterChange(); });
     });
-    ['pt-f-channel', 'pt-f-bidType', 'pt-f-user'].forEach(function (id) {
+    ['pt-f-channel', 'pt-f-bidType', 'pt-f-user', 'pt-f-dueDate'].forEach(function (id) {
       var el = document.getElementById(id), key = id.replace('pt-f-', '');
       if (el) el.addEventListener('change', function () { st.filters[key] = el.value; onFilterChange(true); });
     });
     var clear = $('#pt-clear');
     if (clear) clear.addEventListener('click', function () {
       st.filters = EMPTY_FILTERS();
-      ['pt-f-quoteId', 'pt-f-emailCode', 'pt-f-channel', 'pt-f-bidType', 'pt-f-user'].forEach(function (id) {
+      ['pt-f-quoteId', 'pt-f-emailCode', 'pt-f-channel', 'pt-f-bidType', 'pt-f-user', 'pt-f-dueDate'].forEach(function (id) {
         var el = document.getElementById(id); if (el) el.value = '';
       });
       syncStatusMs();

--- a/plantillas/quote/validacion_registro_cotizacion.inc.php
+++ b/plantillas/quote/validacion_registro_cotizacion.inc.php
@@ -12,6 +12,7 @@ if (isset($_POST['registrar_cotizacion'])) {
     $_POST['email_code'],
     $_POST['issue_date'],
     $_POST['end_date'],
+    $_POST['internal_due_date'] ?? '',
     $_POST['type_of_bid'],
     $_POST['usuario_designado'],
     $_POST['canal']
@@ -100,7 +101,7 @@ function createAndInsertQuote($validador, $usuario_designado) {
     'site_visit'       => isset($_POST['site_visit'])  && $_POST['site_visit']  !== '' ? (int)$_POST['site_visit']  : null,
     'resumes'          => isset($_POST['resumes'])     && $_POST['resumes']     !== '' ? (int)$_POST['resumes']     : null,
     'qa_deadline'      => !empty($_POST['qa_deadline'])      ? $_POST['qa_deadline']      : null,
-    'internal_due_date'=> !empty($_POST['internal_due_date'])? $_POST['internal_due_date']: null,
+    'internal_due_date'=> $validador->obtener_internal_due_date(),
     'qa'               => isset($_POST['qa'])             && $_POST['qa']             !== '' ? (int)$_POST['qa']             : null,
   ]);
 

--- a/plantillas/utilities/pipeline_metrics.inc.php
+++ b/plantillas/utilities/pipeline_metrics.inc.php
@@ -126,6 +126,7 @@ $pm_statuses  = PipelineMetricsRepository::STATUSES;
         <?php
         $pm_cards = [
           ['key' => 'status',    'span' => 'full', 'title' => 'Status distribution',           'hint' => 'All pipeline buckets'],
+          ['key' => 'byUser',    'span' => 'full', 'title' => 'Status by user',                 'hint' => 'Per-user pipeline breakdown'],
           ['key' => 'winloss',   'span' => '',     'title' => 'Win / Loss rate',                'hint' => 'Awarded · No Award · Pending'],
           ['key' => 'awards',    'span' => '',     'title' => 'Awards by service category',     'hint' => 'Won bids per category'],
           ['key' => 'submitted', 'span' => '',     'title' => 'Submitted by service category',  'hint' => 'Submissions per category'],
@@ -209,6 +210,18 @@ $pm_statuses  = PipelineMetricsRepository::STATUSES;
                   <?php foreach ($pm_users as $u): ?>
                     <option value="<?= (int)$u['id']; ?>"><?= htmlspecialchars($u['nombre_usuario']); ?></option>
                   <?php endforeach; ?>
+                </select>
+              </div>
+            </div>
+            <div class="pt-field">
+              <span class="pt-field-label">Internal Due Date</span>
+              <div class="pt-select-wrap">
+                <select class="pt-input pt-select" id="pt-f-dueDate">
+                  <option value="">Any due date</option>
+                  <option value="today">Today</option>
+                  <option value="tomorrow">Tomorrow</option>
+                  <option value="week">Next 7 days</option>
+                  <option value="overdue">Overdue</option>
                 </select>
               </div>
             </div>

--- a/scripts/quote/pipeline_metrics_drilldown.php
+++ b/scripts/quote/pipeline_metrics_drilldown.php
@@ -6,6 +6,7 @@
  *   type=category bucket=awards|submitted  category=<type_of_bid>
  *   type=priced   key=submitted|not_submitted|no_bid
  *   type=winloss  key=won|lost|pending
+ *   type=byUser   key=<status key>  user=<usuario_designado id>
  */
 if (!ControlSesion::sesion_iniciada()) {
   http_response_code(401);
@@ -22,7 +23,7 @@ if ($mode === 'quarter') $period['quarter'] = max(1, min(4, (int)($_GET['quarter
 if ($mode === 'month')   $period['month']   = max(1, min(12, (int)($_GET['month'] ?? date('n'))));
 
 $spec = ['type' => $_GET['type'] ?? ''];
-foreach (['key', 'bucket', 'category'] as $k) {
+foreach (['key', 'bucket', 'category', 'user'] as $k) {
   if (isset($_GET[$k])) $spec[$k] = $_GET[$k];
 }
 

--- a/scripts/quote/pipeline_metrics_export.php
+++ b/scripts/quote/pipeline_metrics_export.php
@@ -22,7 +22,7 @@ if ($mode === 'quarter') $period['quarter'] = max(1, min(4, (int)($_GET['quarter
 if ($mode === 'month')   $period['month']   = max(1, min(12, (int)($_GET['month'] ?? date('n'))));
 
 $chart = $_GET['chart'] ?? 'all';
-$valid = ['status', 'winloss', 'awards', 'submitted', 'pricing'];
+$valid = ['status', 'winloss', 'awards', 'submitted', 'pricing', 'byUser'];
 $which = in_array($chart, $valid, true) ? [$chart] : $valid;
 
 Conexion::abrir_conexion();
@@ -103,6 +103,15 @@ foreach ($which as $key) {
     $rows = array_map(fn($b) => [$b['label'], $b['count']], $m['pricing']['buckets']);
     $rows[] = ['Total priced bids', $m['pricing']['total']];
     $addSheet('Pricing Effort', ['Outcome', 'Count'], $rows);
+  } elseif ($key === 'byUser') {
+    $statusLabels = array_column(PipelineMetricsRepository::STATUSES, 'label');
+    $statusKeys   = array_column(PipelineMetricsRepository::STATUSES, 'key');
+    $rows = array_map(function ($u) use ($statusKeys) {
+      $row = [$u['userName']];
+      foreach ($statusKeys as $sk) { $row[] = $u['counts'][$sk]; }
+      return $row;
+    }, $m['byUser']);
+    $addSheet('Status by User', array_merge(['User'], $statusLabels), $rows);
   }
 }
 

--- a/scripts/quote/pipeline_table.php
+++ b/scripts/quote/pipeline_table.php
@@ -2,7 +2,7 @@
 /**
  * JSON: one page of the Bid Pipeline Metrics "Table" view.
  * Params (GET): period (mode=year|quarter|month|custom, year, quarter, month, from, to),
- *   page, and filters: quoteId, channel, emailCode, statuses[], bidType, user.
+ *   page, and filters: quoteId, channel, emailCode, statuses[], bidType, user, dueDate.
  * Each row carries everything the Quote Summary modal needs (name, value, docs, context).
  */
 if (!ControlSesion::sesion_iniciada()) {
@@ -27,6 +27,9 @@ if ($mode === 'custom') {
 $statuses = $_GET['statuses'] ?? [];
 if (!is_array($statuses)) $statuses = [$statuses];
 
+$dueDate = trim((string)($_GET['dueDate'] ?? ''));
+$dueDate = in_array($dueDate, ['today', 'tomorrow', 'week', 'overdue'], true) ? $dueDate : '';
+
 $filters = [
   'quoteId'   => trim((string)($_GET['quoteId'] ?? '')),
   'channel'   => trim((string)($_GET['channel'] ?? '')),
@@ -34,6 +37,7 @@ $filters = [
   'statuses'  => $statuses,
   'bidType'   => trim((string)($_GET['bidType'] ?? '')),
   'user'      => trim((string)($_GET['user'] ?? '')),
+  'dueDate'   => $dueDate,
 ];
 $page = max(0, (int)($_GET['page'] ?? 0));
 

--- a/scripts/quote/save_information.php
+++ b/scripts/quote/save_information.php
@@ -1,5 +1,10 @@
 <?php
 if (isset($_POST['save_information'])) {
+  if (empty($_POST['internal_due_date'])) {
+    header('Content-Type: application/json');
+    echo json_encode(['success' => false, 'message' => 'Internal Due Date must be filled out.']);
+    return;
+  }
   try {
     // Open database connection
     Conexion::abrir_conexion();

--- a/tests/php/internal_due_date_test.php
+++ b/tests/php/internal_due_date_test.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Integration test for the Internal Due Date required field (feature: internal-due-date.md).
+ *
+ * Covers ValidadorCotizacionRegistro: blank Internal Due Date fails validation with the
+ * same "Must be fill out." message End Date already uses; filled passes and the value is
+ * retained. The Table-view preset filter itself is covered in pipeline_table_test.php.
+ *
+ * Run:  docker exec lamp-php84 php /var/www/html/rfq/tests/php/internal_due_date_test.php
+ */
+
+$root = __DIR__ . '/../../';
+require_once $root . 'app/Bootstrap/config.inc.php';
+require_once $root . 'app/Bootstrap/Conexion.inc.php';
+require_once $root . 'app/Quote/RepositorioRfq.inc.php';
+require_once $root . 'app/Quote/ValidadorCotizacion.inc.php';
+require_once $root . 'app/Quote/ValidadorCotizacionRegistro.inc.php';
+
+$pass = 0; $fail = 0;
+function check($label, $expected, $actual) {
+  global $pass, $fail;
+  $ok = $expected === $actual;
+  if ($ok) { $pass++; echo "  PASS  $label\n"; }
+  else     { $fail++; echo "  FAIL  $label — expected " . var_export($expected, true) . ", got " . var_export($actual, true) . "\n"; }
+}
+
+Conexion::abrir_conexion();
+$conexion = Conexion::obtener_conexion();
+
+echo "[ValidadorCotizacionRegistro — Internal Due Date required]\n";
+
+$blank = new ValidadorCotizacionRegistro(
+  $conexion, 'IDD-' . uniqid(), '01/01/2099', '01/02/2099', '', 'IT', 'RSantos', 'GSA-Buy'
+);
+check('blank internal_due_date -> "Must be fill out." error', 'Must be fill out.', $blank->obtener_error_internal_due_date());
+check('blank internal_due_date -> registro_cotizacion_valida() false', false, $blank->registro_cotizacion_valida());
+
+$filled = new ValidadorCotizacionRegistro(
+  $conexion, 'IDD-' . uniqid(), '01/01/2099', '01/02/2099', '01/15/2099', 'IT', 'RSantos', 'GSA-Buy'
+);
+check('filled internal_due_date -> no error', '', $filled->obtener_error_internal_due_date());
+check('filled internal_due_date -> value retained', '01/15/2099', $filled->obtener_internal_due_date());
+check('filled internal_due_date -> registro_cotizacion_valida() true', true, $filled->registro_cotizacion_valida());
+
+// No cross-field constraint against End Date (matches Issue Date/End Date convention).
+$anyOrder = new ValidadorCotizacionRegistro(
+  $conexion, 'IDD-' . uniqid(), '06/01/2099', '01/01/2099', '01/01/2050', 'IT', 'RSantos', 'GSA-Buy'
+);
+check('internal_due_date has no cross-field date constraint', true, $anyOrder->registro_cotizacion_valida());
+
+Conexion::cerrar_conexion();
+
+echo "\n$pass passed, $fail failed\n";
+exit($fail === 0 ? 0 : 1);

--- a/tests/php/pipeline_metrics_test.php
+++ b/tests/php/pipeline_metrics_test.php
@@ -194,6 +194,42 @@ try {
   $sd = PipelineMetricsRepository::getDrillDown($conexion, $svcPeriod, ['type' => 'status', 'key' => 'award']);
   check('drill-down row value includes services subtotal', 150.0, (float)($sd[0]['value'] ?? 0));
 
+  // ---- Status by user (feature: pipeline-status-by-user.md) ----
+  echo "[Status by user]\n";
+  $mkUser = function ($name) use ($conexion) {
+    $stmt = $conexion->prepare("INSERT INTO usuarios (nombre_usuario, password, nombres, apellidos, cargo, email, status, notif_inapp, notif_email)
+                                 VALUES (:u, 'x', :n, 'Test', '3', :e, 1, 1, 0)");
+    $stmt->execute([':u' => $name, ':n' => $name, ':e' => $name . '@test.local']);
+    return (int)$conexion->lastInsertId();
+  };
+  $BU_YEAR = 2096;
+  $buPeriod = ['mode' => 'year', 'year' => $BU_YEAR];
+  $userZ = $mkUser('pm_zzz_' . uniqid()); // sorts after userA alphabetically
+  $userA = $mkUser('pm_aaa_' . uniqid());
+  $buZ1 = insertQuote($conexion, $BU_YEAR, ['usuario_designado' => $userZ, 'award' => 1, 'status' => 1, 'completado' => 1, 'type_of_bid' => 'IT']);
+  $buZ2 = insertQuote($conexion, $BU_YEAR, ['usuario_designado' => $userZ, 'completado' => 1, 'comments' => 'No comments']);
+  $buA1 = insertQuote($conexion, $BU_YEAR, ['usuario_designado' => $userA, 'status' => 1, 'completado' => 1]);
+  // usuario_designado is NOT NULL with no FK constraint; a dangling id (no matching usuarios row)
+  // is how an "unassigned" quote is represented — the INNER JOIN to usuarios excludes it.
+  insertQuote($conexion, $BU_YEAR, ['usuario_designado' => 999999, 'completado' => 1]);
+
+  $byUser = PipelineMetricsRepository::getStatusByUser($conexion, $buPeriod);
+  check('byUser: 2 users with quotes (no-designated-user excluded)', 2, count($byUser));
+  check('byUser: sorted alphabetically (aaa before zzz)', $userA, $byUser[0]['userId']);
+  check('byUser: userZ total = 2', 2, $byUser[1]['total']);
+  check('byUser: userZ award count = 1', 1, $byUser[1]['counts']['award']);
+  check('byUser: userZ bid count = 1', 1, $byUser[1]['counts']['bid']);
+  check('byUser: all 10 status keys present, zero-filled', 10, count($byUser[0]['counts']));
+
+  $mFull = PipelineMetricsRepository::getMetrics($conexion, $buPeriod);
+  check('getMetrics() wires byUser through', count($byUser), count($mFull['byUser']));
+
+  $dUserAward = PipelineMetricsRepository::getDrillDown($conexion, $buPeriod, ['type' => 'byUser', 'user' => $userZ, 'key' => 'award']);
+  check('drill byUser scoped to userZ+award returns 1', 1, count($dUserAward));
+  check('drill byUser row is the right quote', $buZ1, $dUserAward[0]['id'] ?? null);
+  $dUserWrong = PipelineMetricsRepository::getDrillDown($conexion, $buPeriod, ['type' => 'byUser', 'user' => $userA, 'key' => 'award']);
+  check('drill byUser scoped to userA+award returns 0 (userA has no award)', 0, count($dUserWrong));
+
 } finally {
   $conexion->rollBack(); // leave the DB exactly as we found it
 }

--- a/tests/php/pipeline_table_test.php
+++ b/tests/php/pipeline_table_test.php
@@ -92,6 +92,26 @@ try {
   $values = array_column($channels, 'value');
   check('distinct channels includes our test channel', true, in_array('FedBid', $values, true));
 
+  // --- Internal Due Date filter (feature: internal-due-date.md) ---
+  $today    = $mkRfq(['internal_due_date' => date('Y-m-d')]);
+  $tomorrow = $mkRfq(['internal_due_date' => date('Y-m-d', strtotime('+1 day'))]);
+  $inFive   = $mkRfq(['internal_due_date' => date('Y-m-d', strtotime('+5 day'))]);
+  $overdue  = $mkRfq(['internal_due_date' => date('Y-m-d', strtotime('-2 day'))]);
+  $noDue    = $mkRfq(['internal_due_date' => null]);
+
+  $dToday = PipelineTableRepository::getPage($c, $year, array_merge($noF, ['dueDate' => 'today']), 0);
+  check('dueDate=today -> 1', 1, $dToday['total']);
+  $dTomorrow = PipelineTableRepository::getPage($c, $year, array_merge($noF, ['dueDate' => 'tomorrow']), 0);
+  check('dueDate=tomorrow -> 1', 1, $dTomorrow['total']);
+  $dWeek = PipelineTableRepository::getPage($c, $year, array_merge($noF, ['dueDate' => 'week']), 0);
+  check('dueDate=week (rolling 0-7 days, incl. today/tomorrow) -> 3', 3, $dWeek['total']);
+  $dOverdue = PipelineTableRepository::getPage($c, $year, array_merge($noF, ['dueDate' => 'overdue']), 0);
+  check('dueDate=overdue -> 1', 1, $dOverdue['total']);
+
+  // AND-combines with the period: same due date, wrong year -> 0 rows
+  $dWrongYear = PipelineTableRepository::getPage($c, ['mode' => 'year', 'year' => 2098], array_merge($noF, ['dueDate' => 'today']), 0);
+  check('dueDate=today + non-matching period -> 0 (AND-combined)', 0, $dWrongYear['total']);
+
 } finally {
   $c->rollBack();
   Conexion::cerrar_conexion();

--- a/tests/specs/11-checklist-info-drawer.spec.js
+++ b/tests/specs/11-checklist-info-drawer.spec.js
@@ -88,11 +88,23 @@ test.describe('Quote Checklist & Info Drawer', () => {
   test('saving the information tab succeeds via AJAX and shows an inline success pill', async ({ page }) => {
     await page.click('#qed-open-information');
     await page.fill('#reference_url', 'https://example.com/pw-test');
+    await page.fill('#internal_due_date', '02/15/2026'); // required field — see internal-due-date feature
     await Promise.all([
       page.waitForResponse((res) => res.url().includes('/quote/save_information/') && res.status() === 200),
       page.click('#qed-information-save-btn'),
     ]);
     await expect(page.locator('#qed-information-save-pill')).toHaveClass(/is-shown/);
+    await expect(page.locator('#qed-drawer')).toHaveClass(/is-open/);
+  });
+
+  test('saving the information tab with Internal Due Date blank fails and shows the error banner', async ({ page }) => {
+    await page.click('#qed-open-information');
+    await page.fill('#internal_due_date', '');
+    await Promise.all([
+      page.waitForResponse((res) => res.url().includes('/quote/save_information/') && res.status() === 200),
+      page.click('#qed-information-save-btn'),
+    ]);
+    await expect(page.locator('#qed-information-error')).toBeVisible();
     await expect(page.locator('#qed-drawer')).toHaveClass(/is-open/);
   });
 


### PR DESCRIPTION
## Summary
- **Internal Due Date table filter** — new 7th filter on the Pipeline Table view (Today/Tomorrow/Next 7 days/Overdue presets), AND-combined with the existing filters and period.
- **Internal Due Date required field** — now required on the New Quote form (native `required` + server-side validator, "Must be fill out." pattern matching End Date) and on the Information drawer tab (save rejects a blank value pre-write, surfaced through the existing error banner).
- **Status by User chart** — new full-width stacked-bar card on the dashboard directly under Status Distribution, one bar per designated user (10-status colors, alphabetical), Count/Percent aware, with drill-down and Excel export.
- **Wider drill-down drawer** — `.pm-drawer` is now `50vw` (was a fixed `430px`) for every drill-down on the page.

Implements `features/internal-due-date.md` and `features/pipeline-status-by-user.md` (now removed, since built). Not ported from the design mockup: per-quote "watch" star icons — `CLAUDE.md` documents that subsystem was built once and deliberately removed; a regression test (`pipeline_table_test.php`) guards against reintroducing it.

## Test plan
- [x] Full PHP integration suite (`tests/php/*`) — all green, including new/extended `pipeline_table_test.php`, `pipeline_metrics_test.php`, and new `internal_due_date_test.php`
- [x] `php -l` clean on every touched file
- [x] Full Playwright E2E suite (98 tests) — all green, including one pre-existing test fixed to fill the now-required field
- [x] Manual browser verification: due-date filter, Status by User chart render + drill-down, wider drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)